### PR TITLE
feat: add k9s plugin for loogtui

### DIFF
--- a/compat/k9s/plugins.yaml
+++ b/compat/k9s/plugins.yaml
@@ -1,0 +1,37 @@
+plugins:
+  loog-run-selected:
+    shortCut: Shift-L
+    confirm: false
+    scopes:
+      - all
+    description: "👀: Run Selected"
+    command: bash
+    background: false
+    args:
+      - -c
+      - >
+        loogtui
+        -resource
+        $RESOURCE_GROUP/$RESOURCE_VERSION/$RESOURCE_NAME
+        -out
+        /tmp/output.loog
+        -filter-expr
+        'Namespaced("$NAMESPACE", "$NAME")'
+  loog-run-namespace:
+    shortCut: Ctrl-L
+    confirm: true
+    scopes:
+      - all
+    description: "👀: Run Namespace"
+    command: bash
+    background: false
+    args:
+      - -c
+      - >
+        loogtui
+        -resource
+        $RESOURCE_GROUP/$RESOURCE_VERSION/$RESOURCE_NAME
+        -out
+        /tmp/output.loog
+        -filter-expr
+        'Namespace("$NAMESPACE")'


### PR DESCRIPTION
This pull requests adds a `plugins.yaml` file that can be used to start loogtui from k9s.

`Shift-L`: Starts loogtui with the currently highlighted resource as expression filter.
`Ctrl-L`: Starts loogtui with the currently selected namespace as expression filter.