### PR TITLE
feat: use temp files by default

### DIFF
--- a/cmd/loogtui/main.go
+++ b/cmd/loogtui/main.go
@@ -57,8 +57,9 @@ func main() {
 			log.Fatal("Cannot create temp file:", err)
 			return
 		}
+		defer file.Close()
+		defer os.Remove(file.Name())
 		flagOutFile = file.Name()
-		log.Println("Using temp file:", flagOutFile)
 	}
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()

--- a/cmd/loogtui/main.go
+++ b/cmd/loogtui/main.go
@@ -36,7 +36,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&flagOutFile, "out", "output.loog", "dump output file")
+	flag.StringVar(&flagOutFile, "out", "", "dump output file")
 	flag.BoolVar(&flagNotDurable, "not-durable", false, "if set to true, the store won't fsync every commit")
 	flag.BoolVar(&flagNoCache, "no-cache", false, "if set to true, the store won't cache the data")
 	flag.Uint64Var(&flagSnapshotEvery, "snapshot-every", 8, "patches until snapshot")
@@ -51,6 +51,15 @@ func init() {
 
 func main() {
 	flag.Parse()
+	if flagOutFile == "" {
+		file, err := os.CreateTemp("", "loog-output-*.loog")
+		if err != nil {
+			log.Fatal("Cannot create temp file:", err)
+			return
+		}
+		flagOutFile = file.Name()
+		log.Println("Using temp file:", flagOutFile)
+	}
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 

--- a/cmd/loogtui/main.go
+++ b/cmd/loogtui/main.go
@@ -57,8 +57,10 @@ func main() {
 			log.Fatal("Cannot create temp file:", err)
 			return
 		}
-		defer file.Close()
-		defer os.Remove(file.Name())
+		defer func() {
+			file.Close()
+			os.Remove(file.Name())
+		}()
 		flagOutFile = file.Name()
 	}
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)

--- a/compat/k9s/plugins.yaml
+++ b/compat/k9s/plugins.yaml
@@ -13,8 +13,6 @@ plugins:
         loogtui
         -resource
         $RESOURCE_GROUP/$RESOURCE_VERSION/$RESOURCE_NAME
-        -out
-        /tmp/output.loog
         -filter-expr
         'Namespaced("$NAMESPACE", "$NAME")'
   loog-run-namespace:
@@ -31,7 +29,5 @@ plugins:
         loogtui
         -resource
         $RESOURCE_GROUP/$RESOURCE_VERSION/$RESOURCE_NAME
-        -out
-        /tmp/output.loog
         -filter-expr
         'Namespace("$NAMESPACE")'


### PR DESCRIPTION
This pull request changes the default logic for the logtui in regards to the -out filepath flag. If it is not supplied, a tempfile is used.