### PR TITLE
feat(tui): read db on startup

### DIFF
--- a/cmd/loogtui/main.go
+++ b/cmd/loogtui/main.go
@@ -3,6 +3,12 @@ package main
 import (
 	"context"
 	"flag"
+	"log"
+	"maps"
+	"os"
+	"os/signal"
+	"path/filepath"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/expr-lang/expr"
 	"github.com/expr-lang/expr/vm"
@@ -18,11 +24,6 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
-	"log"
-	"maps"
-	"os"
-	"os/signal"
-	"path/filepath"
 )
 
 var (

--- a/cmd/loogtui/main.go
+++ b/cmd/loogtui/main.go
@@ -125,9 +125,6 @@ func runCollector(
 			return false
 		}
 		u := &unstructured.Unstructured{Object: snapshot.Object}
-		if snapshot.Time.IsZero() {
-			panic("snapshot time is zero")
-		}
 
 		p.Send(ui.NewCommitCommand(
 			string(u.GetUID()),

--- a/cmd/loogtui/main.go
+++ b/cmd/loogtui/main.go
@@ -200,11 +200,12 @@ func loadHistoryFromDB(rps store.ResourcePatchStore, trackerService *service.Tra
 		}
 		objectRevisionState[objectUID] = current
 		trackerService.WarmCache(objectUID, current)
+		unstructuredObj := &unstructured.Unstructured{Object: current.Object}
 		p.Send(ui.NewCommitCommand(
 			objectUID,
-			current.Object["kind"].(string),
-			current.Object["metadata"].(map[string]any)["name"].(string),
-			current.Object["metadata"].(map[string]any)["namespace"].(string),
+			unstructuredObj.GetKind(),
+			unstructuredObj.GetName(),
+			unstructuredObj.GetNamespace(),
 			revisionID,
 			current,
 			patch,

--- a/internal/service/tracker_service.go
+++ b/internal/service/tracker_service.go
@@ -95,7 +95,7 @@ func (t *TrackerService) Commit(
 				return 0, err
 			}
 
-			snapshot := store.Snapshot{Object: newObject.Object, Time: time.Now()}
+			snapshot := newSnapshot(newObject, 0)
 			if err := t.rps.SetSnapshot(ctx, objID, &snapshot); err != nil {
 				return 0, err
 			}
@@ -121,11 +121,7 @@ func (t *TrackerService) Commit(
 	patchesSince := uint64(ts.rev) % t.snapshotEvery
 	if patchesSince == t.snapshotEvery-1 {
 		// we are at the end of a snapshot period, so we should create a new snapshot
-		snapshot := store.Snapshot{
-			PreviousID: ts.rev,
-			Object:     newObject.Object,
-			Time:       time.Now(),
-		}
+		snapshot := newSnapshot(newObject, ts.rev)
 		err := t.rps.SetSnapshot(ctx, objID, &snapshot)
 		if err != nil {
 			return 0, err
@@ -139,12 +135,8 @@ func (t *TrackerService) Commit(
 	}
 
 	diff := diffmap.Diff(ts.obj, newObject.Object)
-	p := &store.Patch{
-		PreviousID: ts.rev,
-		Patch:      diff,
-		Time:       time.Now(),
-	}
-	err := t.rps.SetPatch(ctx, objID, p)
+	p := newPatch(ts.rev, diff)
+	err := t.rps.SetPatch(ctx, objID, &p)
 	if err != nil {
 		return 0, err
 	}
@@ -155,6 +147,19 @@ func (t *TrackerService) Commit(
 	ts.rev = p.ID
 
 	return p.ID, nil
+}
+
+func newPatch(previousID store.RevisionID, diff diffmap.DiffMap) store.Patch {
+	return store.Patch{
+		PreviousID: previousID,
+		Patch:      diff,
+		Time:       time.Now(),
+	}
+}
+
+func newSnapshot(newObject *unstructured.Unstructured, previousID store.RevisionID) store.Snapshot {
+	snapshot := store.Snapshot{PreviousID: previousID, Object: newObject.Object, Time: time.Now()}
+	return snapshot
 }
 
 // Restore brings back the object state at *rev*.

--- a/internal/service/tracker_service.go
+++ b/internal/service/tracker_service.go
@@ -95,7 +95,7 @@ func (t *TrackerService) Commit(
 				return 0, err
 			}
 
-			snapshot := store.Snapshot{Object: newObject.Object}
+			snapshot := store.Snapshot{Object: newObject.Object, Time: time.Now()}
 			if err := t.rps.SetSnapshot(ctx, objID, &snapshot); err != nil {
 				return 0, err
 			}
@@ -124,6 +124,7 @@ func (t *TrackerService) Commit(
 		snapshot := store.Snapshot{
 			PreviousID: ts.rev,
 			Object:     newObject.Object,
+			Time:       time.Now(),
 		}
 		err := t.rps.SetSnapshot(ctx, objID, &snapshot)
 		if err != nil {
@@ -141,6 +142,7 @@ func (t *TrackerService) Commit(
 	p := &store.Patch{
 		PreviousID: ts.rev,
 		Patch:      diff,
+		Time:       time.Now(),
 	}
 	err := t.rps.SetPatch(ctx, objID, p)
 	if err != nil {
@@ -179,6 +181,7 @@ func (t *TrackerService) Restore(ctx context.Context, objID string, revision sto
 			return &store.Snapshot{
 				ID:     revision,
 				Object: state,
+				Time:   snapshot.Time,
 			}, nil
 		}
 

--- a/internal/service/tracker_service.go
+++ b/internal/service/tracker_service.go
@@ -240,3 +240,10 @@ func (t *TrackerService) objLock(uid string) *lockWrap {
 	t.commitLockMutex.Unlock()
 	return mu
 }
+
+func (t *TrackerService) WarmCache(uid string, snapshot *store.Snapshot) {
+	if t.cache == nil {
+		return
+	}
+	t.cache.set(uid, &trackerState{obj: snapshot.Object, rev: snapshot.ID})
+}

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/loog-project/loog/pkg/diffmap"
 )
@@ -24,6 +25,7 @@ type Patch struct {
 	// Patch is an object with the diff between the previous revision and this revision.
 	// see [diffmap.Diff] for more details.
 	Patch diffmap.DiffMap `msgpack:"s" json:"patch,omitempty"`
+	Time  time.Time       `msgpack:"t" json:"time,omitempty"`
 }
 
 type Snapshot struct {
@@ -36,4 +38,5 @@ type Snapshot struct {
 	/// Snapshot Metadata
 	// Object is the actual object being stored in this revision.
 	Object diffmap.DiffMap `msgpack:"o" json:"object,omitempty"`
+	Time   time.Time       `msgpack:"t" json:"time,omitempty"`
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -18,5 +18,6 @@ type ResourcePatchStore interface {
 	SetPatch(ctx context.Context, objectID string, p *Patch) error
 
 	GetLatestRevision(ctx context.Context, objectID string) (RevisionID, error)
+	WalkObjectRevisions(yield func(string, RevisionID, *Snapshot, *Patch) bool) error
 	Close() error
 }

--- a/internal/ui/helpers.go
+++ b/internal/ui/helpers.go
@@ -1,11 +1,8 @@
 package ui
 
 import (
-	"time"
-
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/loog-project/loog/internal/store"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type Base struct {
@@ -44,9 +41,11 @@ type alertMsg struct {
 }
 
 type commitMsg struct {
-	Time     time.Time
-	Object   *unstructured.Unstructured
+	//Object   *unstructured.Unstructured
 	Revision store.RevisionID
+
+	// Object Meta
+	UID, Kind, Name, Namespace string
 
 	// it's either a snapshot OR a patch,
 	// one of those must be nil, the other must be set
@@ -78,18 +77,19 @@ func PushAlert(title string, err error) tea.Cmd {
 
 // NewCommitCommand creates a command that pushes a commit message to the root model.
 func NewCommitCommand(
-	received time.Time,
-	obj *unstructured.Unstructured,
+	uid, kind, name, namespace string,
 	rev store.RevisionID,
 	snapshot *store.Snapshot,
 	patch *store.Patch,
 ) tea.Msg {
 	return commitMsg{
-		Time:     received,
-		Object:   obj,
-		Revision: rev,
-		Snapshot: snapshot,
-		Patch:    patch,
+		Revision:  rev,
+		UID:       uid,
+		Kind:      kind,
+		Name:      name,
+		Namespace: namespace,
+		Snapshot:  snapshot,
+		Patch:     patch,
 	}
 }
 


### PR DESCRIPTION
This pull request implements the logic to read existing patches and snapshots in a db file when loogtui is started. This can be used to view a recorded dump at a later time or add new entries to an existing dump.