### PR TITLE
feat: add S2 compression and pooled codecs for the store layer

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,7 @@ var (
 	outputFile       string
 	noDurableSync    bool
 	disableCache     bool
+	disableCompress  bool
 	snapshotInterval uint64
 	filterExpr       string
 	headlessMode     bool
@@ -95,6 +96,8 @@ func init() {
 		"Skip fsync on every commit to improve throughput (unsafe on crashes)")
 	rootCmd.Flags().BoolVar(&disableCache, "disable-cache", false,
 		"Disable in‑memory cache layer for the revision store")
+	rootCmd.Flags().BoolVar(&disableCompress, "no-compress", false,
+		"Disable s2 compression for stored payloads (larger DB but slightly less CPU)")
 	rootCmd.Flags().Uint64VarP(&snapshotInterval, "snapshot-interval", "s", 8,
 		"Create a full snapshot after this many patches (default 8)")
 
@@ -201,7 +204,10 @@ func run(ctx context.Context, args []string) error {
 	setupLog.Info().
 		Str("store-file", outputFile).
 		Msg("Preparing object revision store...")
-	rps, err := bboltStore.New(outputFile, nil, !noDurableSync)
+	rps, err := bboltStore.NewWithOptions(outputFile, bboltStore.Options{
+		Durable:  !noDurableSync,
+		Compress: !disableCompress,
+	})
 	if err != nil {
 		setupLog.Fatal().Err(err).Msg("Error preparing store")
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/expr-lang/expr v1.17.8
+	github.com/klauspost/compress v1.18.5
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
+github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=

--- a/internal/store/bbolt/helpers.go
+++ b/internal/store/bbolt/helpers.go
@@ -3,32 +3,64 @@ package bbolt
 import (
 	"bytes"
 	"encoding/binary"
+	"sync"
 
+	"github.com/klauspost/compress/s2"
 	"go.etcd.io/bbolt"
 
 	"github.com/loog-project/loog/internal/store"
 )
 
+// Pool for key construction buffers. Most object UIDs are 36-char UUIDs,
+// so 36+1+8 = 45 bytes is the common size.
+var keyPool = sync.Pool{
+	New: func() any {
+		return new(make([]byte, 0, 64))
+	},
+}
+
 func keyObjectRevision(objectUID string, id store.RevisionID) []byte {
-	buf := make([]byte, len(objectUID)+1+8)
+	size := len(objectUID) + 1 + 8
+	buf := make([]byte, size)
 	copy(buf, objectUID)
 	buf[len(objectUID)] = '|'
 	binary.BigEndian.PutUint64(buf[len(objectUID)+1:], uint64(id))
 	return buf
 }
 
+// keyObjectRevisionPooled writes the key into a pooled buffer and returns it.
+// Caller must call putKeyBuf when done with the returned *[]byte.
+func keyObjectRevisionPooled(objectUID string, id store.RevisionID) *[]byte {
+	bp := keyPool.Get().(*[]byte)
+	size := len(objectUID) + 1 + 8
+	if cap(*bp) < size {
+		*bp = make([]byte, size)
+	} else {
+		*bp = (*bp)[:size]
+	}
+	buf := *bp
+	copy(buf, objectUID)
+	buf[len(objectUID)] = '|'
+	binary.BigEndian.PutUint64(buf[len(objectUID)+1:], uint64(id))
+	return bp
+}
+
+func putKeyBuf(bp *[]byte) {
+	keyPool.Put(bp)
+}
+
 func splitObjectRevisionKey(key []byte) (string, store.RevisionID) {
-	sep := bytes.IndexByte(key, '|')
-	if sep == -1 {
+	before, after, ok := bytes.Cut(key, []byte{'|'})
+	if !ok || len(after) < 8 {
 		return "", 0
 	}
-	objectUID := string(key[:sep])
-	id := binary.BigEndian.Uint64(key[sep+1:])
+	objectUID := string(before)
+	id := binary.BigEndian.Uint64(after)
 	return objectUID, store.RevisionID(id)
 }
 
-// claimNextRevision atomically increments the nextRevisionCounter in bucketLatest *and*
-// updates the in-memory cache. It returns the newly assigned revision number.
+// claimNextRevision atomically increments the nextRevisionCounter in bucketLatest
+// and updates the in-memory cache. Returns the newly assigned revision number.
 func (s *Store) claimNextRevision(tx *bbolt.Tx, objectID string) (store.RevisionID, error) {
 	latest := tx.Bucket(bucketLatest)
 
@@ -41,7 +73,8 @@ func (s *Store) claimNextRevision(tx *bbolt.Tx, objectID string) (store.Revision
 
 	buf := make([]byte, 8)
 	binary.BigEndian.PutUint64(buf, next)
-	if err := latest.Put([]byte(objectID), buf); err != nil {
+	err := latest.Put([]byte(objectID), buf)
+	if err != nil {
 		return 0, err
 	}
 
@@ -52,24 +85,48 @@ func (s *Store) claimNextRevision(tx *bbolt.Tx, objectID string) (store.Revision
 	return revisionNumber, nil
 }
 
-// setLatest updates the latest revision for the given object in the database.
-func (s *Store) setLatest(tx *bbolt.Tx, obj string, revisionID store.RevisionID) error {
-	buf := make([]byte, 8)
-	binary.BigEndian.PutUint64(buf, uint64(revisionID))
-	if err := tx.Bucket(bucketLatest).Put([]byte(obj), buf); err != nil {
-		return err
-	}
-	return nil
+// compressPool reuses destination buffers for s2 compression.
+var compressPool = sync.Pool{
+	New: func() any {
+		return new(make([]byte, 0, 2048))
+	},
+}
+
+// compressPayload compresses raw payload bytes using s2. Returns the
+// compressed bytes (which may be backed by a pooled buffer: caller should copy if the data outlives the current scope).
+func compressPayload(raw []byte) []byte {
+	bp := compressPool.Get().(*[]byte)
+	*bp = s2.Encode(*bp, raw)
+	out := make([]byte, len(*bp))
+	copy(out, *bp)
+	compressPool.Put(bp)
+	return out
+}
+
+// decompressPayload decompresses an s2-compressed payload.
+func decompressPayload(compressed []byte) ([]byte, error) {
+	return s2.Decode(nil, compressed)
 }
 
 func (s *Store) parsePatchOrSnapshot(v []byte) (*store.Snapshot, *store.Patch, error) {
+	if len(v) < 1 {
+		return nil, nil, store.ErrInvalidRevision
+	}
+	payload := v[1:]
+	if s.compress {
+		var err error
+		payload, err = decompressPayload(payload)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 	switch v[0] {
-	case TypePatch:
+	case typePatch:
 		var patch store.Patch
-		return nil, &patch, s.codec.Unmarshal(v[1:], &patch)
-	case TypeSnapshot:
+		return nil, &patch, s.codec.Unmarshal(payload, &patch)
+	case typeSnapshot:
 		var snapshot store.Snapshot
-		return &snapshot, nil, s.codec.Unmarshal(v[1:], &snapshot)
+		return &snapshot, nil, s.codec.Unmarshal(payload, &snapshot)
 	default:
 		return nil, nil, store.ErrInvalidRevision
 	}

--- a/internal/store/bbolt/helpers.go
+++ b/internal/store/bbolt/helpers.go
@@ -15,7 +15,7 @@ import (
 // so 36+1+8 = 45 bytes is the common size.
 var keyPool = sync.Pool{
 	New: func() any {
-		return new(make([]byte, 0, 64))
+		return new(make([]byte, 0, 45))
 	},
 }
 

--- a/internal/store/bbolt/operations.go
+++ b/internal/store/bbolt/operations.go
@@ -3,11 +3,19 @@ package bbolt
 import (
 	"context"
 	"encoding/binary"
+	"sync"
 
 	"go.etcd.io/bbolt"
 
 	"github.com/loog-project/loog/internal/store"
 )
+
+// payloadPool reuses buffers for type-tag + marshalled payload merging.
+var payloadPool = sync.Pool{
+	New: func() any {
+		return new(make([]byte, 0, 2048))
+	},
+}
 
 func (s *Store) Get(
 	_ context.Context,
@@ -15,8 +23,9 @@ func (s *Store) Get(
 	revisionID store.RevisionID,
 ) (snapshot *store.Snapshot, patch *store.Patch, err error) {
 	err = s.db.View(func(tx *bbolt.Tx) error {
-		key := keyObjectRevision(uid, revisionID)
-		v := tx.Bucket(bucketSnapshots).Get(key)
+		bp := keyObjectRevisionPooled(uid, revisionID)
+		v := tx.Bucket(bucketSnapshots).Get(*bp)
+		putKeyBuf(bp)
 		if v == nil {
 			return store.ErrNotFound
 		}
@@ -26,6 +35,41 @@ func (s *Store) Get(
 	return
 }
 
+// storeRevision is the shared write logic for both snapshots and patches.
+// It claims a revision, sets the ID on the value, marshals, optionally
+// compresses, prepends the type tag, and puts the result into bbolt.
+func (s *Store) storeRevision(tx *bbolt.Tx, uid string, typeByte byte, revisionID store.RevisionID, v any) error {
+	key := keyObjectRevision(uid, revisionID)
+	payload, err := s.codec.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	if s.compress {
+		payload = compressPayload(payload)
+	}
+
+	// Merge type tag + payload using pooled buffer
+	bp := payloadPool.Get().(*[]byte)
+	needed := 1 + len(payload)
+	if cap(*bp) < needed {
+		*bp = make([]byte, needed)
+	} else {
+		*bp = (*bp)[:needed]
+	}
+	(*bp)[0] = typeByte
+	copy((*bp)[1:], payload)
+
+	// Copy into a fresh slice before Put — bbolt may hold a reference to the
+	// value bytes beyond the lifetime of the transaction, so we must not
+	// return the pooled buffer while bbolt might still read from it.
+	data := make([]byte, needed)
+	copy(data, *bp)
+	payloadPool.Put(bp)
+
+	return tx.Bucket(bucketSnapshots).Put(key, data)
+}
+
 func (s *Store) SetSnapshot(_ context.Context, uid string, snapshot *store.Snapshot) error {
 	return s.db.Update(func(tx *bbolt.Tx) error {
 		revisionID, err := s.claimNextRevision(tx, uid)
@@ -33,18 +77,7 @@ func (s *Store) SetSnapshot(_ context.Context, uid string, snapshot *store.Snaps
 			return err
 		}
 		snapshot.ID = revisionID
-
-		key := keyObjectRevision(uid, revisionID)
-		payload, err := s.codec.Marshal(snapshot)
-		if err != nil {
-			return err
-		}
-
-		buf := make([]byte, 1+len(payload))
-		buf[0] = TypeSnapshot
-		copy(buf[1:], payload)
-
-		return tx.Bucket(bucketSnapshots).Put(key, buf)
+		return s.storeRevision(tx, uid, typeSnapshot, revisionID, snapshot)
 	})
 }
 
@@ -55,18 +88,7 @@ func (s *Store) SetPatch(_ context.Context, uid string, patch *store.Patch) erro
 			return err
 		}
 		patch.ID = revisionID
-
-		key := keyObjectRevision(uid, revisionID)
-		payload, err := s.codec.Marshal(patch)
-		if err != nil {
-			return err
-		}
-
-		buf := make([]byte, 1+len(payload))
-		buf[0] = TypePatch
-		copy(buf[1:], payload)
-
-		return tx.Bucket(bucketSnapshots).Put(key, buf)
+		return s.storeRevision(tx, uid, typePatch, revisionID, patch)
 	})
 }
 
@@ -104,10 +126,8 @@ func (s *Store) GetLatestRevision(
 }
 
 func (s *Store) WalkObjectRevisions(yield func(string, store.RevisionID, *store.Snapshot, *store.Patch) bool) error {
-	err := s.db.View(func(tx *bbolt.Tx) error {
-		b := tx.Bucket(bucketSnapshots)
-
-		c := b.Cursor()
+	return s.db.View(func(tx *bbolt.Tx) error {
+		c := tx.Bucket(bucketSnapshots).Cursor()
 		for k, v := c.First(); k != nil; k, v = c.Next() {
 			uid, revisionID := splitObjectRevisionKey(k)
 			if uid == "" {
@@ -124,5 +144,4 @@ func (s *Store) WalkObjectRevisions(yield func(string, store.RevisionID, *store.
 		}
 		return nil
 	})
-	return err
 }

--- a/internal/store/bbolt/store.go
+++ b/internal/store/bbolt/store.go
@@ -1,8 +1,12 @@
+// Package bbolt implements [store.ResourcePatchStore] backed by a BoltDB
+// database file. It supports configurable durability, periodic sync, and
+// optional s2 compression.
 package bbolt
 
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/rs/zerolog/log"
 	"go.etcd.io/bbolt"
@@ -11,14 +15,35 @@ import (
 )
 
 const (
-	TypeSnapshot byte = 1 << iota
-	TypePatch
+	typeSnapshot byte = 1 << iota
+	typePatch
 )
 
 var (
-	bucketSnapshots = []byte("snapshots") // <obj>|rev  -> RevisionSnapshot
-	bucketLatest    = []byte("latest")    // <obj>      -> uint64(latestRev)
+	bucketSnapshots = []byte("snapshots") // <obj>|rev  -> type_byte + payload
+	bucketLatest    = []byte("latest")    // <obj>      -> uint64(nextRevisionCounter)
 )
+
+// Options controls how the store behaves.
+type Options struct {
+	// Codec to use for marshal/unmarshal. Nil means DefaultCodec (pooled msgpack).
+	Codec store.Codec
+
+	// Durable controls whether writes are fsynced to disk. When true and
+	// SyncInterval is zero, every write triggers an fsync (safest, slowest).
+	Durable bool
+
+	// SyncInterval, when positive, decouples fsyncs from individual writes.
+	// Writes go to the OS page cache immediately (~30us) and a background
+	// goroutine calls db.Sync() at this interval. On crash, at most one
+	// interval worth of writes may be lost. A good default is 50ms.
+	// Only meaningful when Durable is true; ignored when Durable is false.
+	SyncInterval time.Duration
+
+	// Compress, when true, applies s2 compression to payloads before storing.
+	// Reduces DB file size at a small CPU cost.
+	Compress bool
+}
 
 type Store struct {
 	db    *bbolt.DB
@@ -27,21 +52,39 @@ type Store struct {
 	nextRevisionCounterMutex sync.RWMutex
 	nextRevisionCounter      map[string]uint64
 
-	durable bool
+	compress bool
+
+	stopSync chan struct{} // nil when no periodic sync
 }
 
 var _ store.ResourcePatchStore = (*Store)(nil)
 
-// New opens (or creates) a BoltDB database file.
-// Pass nil for [codec] to use the default MessagePack implementation.
+// New opens (or creates) a BoltDB-backed store. For full control use [NewWithOptions].
 func New(path string, codec store.Codec, durable bool) (*Store, error) {
+	return NewWithOptions(path, Options{
+		Codec:   codec,
+		Durable: durable,
+	})
+}
+
+// NewWithOptions opens (or creates) a BoltDB-backed store with full control
+// over durability, compression, and sync behavior.
+func NewWithOptions(path string, opts Options) (*Store, error) {
+	codec := opts.Codec
 	if codec == nil {
 		codec = store.DefaultCodec
 	}
-	db, err := bbolt.Open(path, 0666, &bbolt.Options{
+
+	// When SyncInterval is set, we disable per-write fsync and sync in the background.
+	noSync := !opts.Durable
+	if opts.Durable && opts.SyncInterval > 0 {
+		noSync = true
+	}
+
+	db, err := bbolt.Open(path, 0600, &bbolt.Options{
 		Timeout:      0,
-		NoSync:       !durable,
-		NoGrowSync:   !durable,
+		NoSync:       noSync,
+		NoGrowSync:   noSync,
 		FreelistType: bbolt.FreelistMapType,
 	})
 	if err != nil {
@@ -64,17 +107,42 @@ func New(path string, codec store.Codec, durable bool) (*Store, error) {
 		db:                  db,
 		codec:               codec,
 		nextRevisionCounter: make(map[string]uint64),
-		durable:             durable,
+		compress:            opts.Compress,
 	}
+
+	// Start periodic sync goroutine if configured.
+	if opts.Durable && opts.SyncInterval > 0 {
+		s.stopSync = make(chan struct{})
+		go s.syncLoop(opts.SyncInterval)
+	}
+
 	return s, nil
 }
 
-// Close closes the database connection.
-func (s *Store) Close() error {
-	if !s.durable {
-		if err := s.db.Sync(); err != nil {
-			log.Error().Err(err).Msg("Error syncing database before closing")
+// syncLoop calls db.Sync() at the given interval until stopSync is closed.
+func (s *Store) syncLoop(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if err := s.db.Sync(); err != nil {
+				log.Error().Err(err).Msg("periodic db.Sync failed")
+			}
+		case <-s.stopSync:
+			return
 		}
+	}
+}
+
+// Close flushes any pending writes and closes the database.
+func (s *Store) Close() error {
+	if s.stopSync != nil {
+		close(s.stopSync)
+	}
+	// Always do a final sync to make sure everything is on disk.
+	if err := s.db.Sync(); err != nil {
+		log.Error().Err(err).Msg("Error syncing database before closing")
 	}
 	return s.db.Close()
 }

--- a/internal/store/bbolt/store_test.go
+++ b/internal/store/bbolt/store_test.go
@@ -3,22 +3,139 @@ package bbolt
 import (
 	"bytes"
 	"context"
+	"errors"
+	"math"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/loog-project/loog/internal/store"
 	"github.com/loog-project/loog/pkg/diffmap"
 )
-
-// handy constants -----------------------------------------------------------
 
 var (
 	ctx = context.Background()
 	id  = "object-uid"
 )
 
-// TestNewAndBuckets checks that the DB opens and buckets exist.
+// equalMaps compares two DiffMaps with tolerance for msgpack numeric type
+// round-tripping. Msgpack decodes integers into the smallest fitting type
+// (e.g. int -> int8), so reflect.DeepEqual fails even though values match.
+func equalMaps(t *testing.T, got, want diffmap.DiffMap) bool {
+	t.Helper()
+	return equalAny(t, "", got, want)
+}
+
+func equalAny(t *testing.T, path string, got, want any) bool {
+	t.Helper()
+
+	// nil
+	if got == nil && want == nil {
+		return true
+	}
+	if (got == nil) != (want == nil) {
+		t.Errorf("%s: got=%v want=%v (nil mismatch)", path, got, want)
+		return false
+	}
+
+	// both DiffMap / map[string]any
+	gm, gok := toMap(got)
+	wm, wok := toMap(want)
+	if gok && wok {
+		if len(gm) != len(wm) {
+			t.Errorf("%s: map len got=%d want=%d", path, len(gm), len(wm))
+			return false
+		}
+		ok := true
+		for k, wv := range wm {
+			gv, has := gm[k]
+			if !has {
+				t.Errorf("%s: missing key %q", path, k)
+				ok = false
+				continue
+			}
+			if !equalAny(t, path+"."+k, gv, wv) {
+				ok = false
+			}
+		}
+		return ok
+	}
+
+	gn, gnOk := toFloat64(got)
+	wn, wnOk := toFloat64(want)
+	if gnOk && wnOk {
+		if gn != wn {
+			t.Errorf("%s: got=%v want=%v (numeric mismatch)", path, got, want)
+			return false
+		}
+		return true
+	}
+
+	// fallback: reflect
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("%s: got=%v (%T) want=%v (%T)", path, got, got, want, want)
+		return false
+	}
+	return true
+}
+
+func toMap(v any) (map[string]any, bool) {
+	if m, ok := v.(map[string]any); ok {
+		return m, true
+	}
+	return nil, false
+}
+
+func toFloat64(v any) (float64, bool) {
+	switch n := v.(type) {
+	case int:
+		return float64(n), true
+	case int8:
+		return float64(n), true
+	case int16:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case uint:
+		return float64(n), true
+	case uint8:
+		return float64(n), true
+	case uint16:
+		return float64(n), true
+	case uint32:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	case float32:
+		return float64(n), true
+	case float64:
+		return n, true
+	}
+	return 0, false
+}
+
+// helper to open a store with options and register cleanup.
+func openStore(t *testing.T, opts Options) *Store {
+	t.Helper()
+	s, err := NewWithOptions(filepath.Join(t.TempDir(), "test.bb"), opts)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// Basic functionality
+// ---------------------------------------------------------------------------
+
 func TestNewAndBuckets(t *testing.T) {
 	dir := t.TempDir()
 	s, err := New(filepath.Join(dir, "db.bb"), nil, false)
@@ -27,23 +144,15 @@ func TestNewAndBuckets(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = s.Close() })
 
-	// verify buckets truly created in file
 	info1, _ := os.Stat(s.db.Path())
 	if info1.Size() == 0 {
 		t.Fatal("DB file should not be empty")
 	}
 }
 
-// TestSnapshotPatchRoundtrip covers:
-//   - claimNextRevision
-//   - SetSnapshot / SetPatch
-//   - Get / GetLatestRevision
 func TestSnapshotPatchRoundtrip(t *testing.T) {
-	dir := t.TempDir()
-	s, _ := New(filepath.Join(dir, "db.bb"), nil, false)
-	t.Cleanup(func() { _ = s.Close() })
+	s := openStore(t, Options{})
 
-	// -------- 1st snapshot -----------------------------------------------
 	snap := &store.Snapshot{Object: diffmap.DiffMap{"foo": "bar"}}
 	if err := s.SetSnapshot(ctx, id, snap); err != nil {
 		t.Fatalf("set snapshot: %v", err)
@@ -52,7 +161,6 @@ func TestSnapshotPatchRoundtrip(t *testing.T) {
 		t.Fatalf("first snapshot should have ID 0, got %d", snap.ID)
 	}
 
-	// latest should now be 0
 	latest, err := s.GetLatestRevision(ctx, id)
 	if err != nil {
 		t.Fatalf("get latest: %v", err)
@@ -61,11 +169,7 @@ func TestSnapshotPatchRoundtrip(t *testing.T) {
 		t.Fatalf("latest want 0, got %d", latest)
 	}
 
-	// -------- patch #1 ----------------------------------------------------
-	patch1 := &store.Patch{
-		PreviousID: snap.ID,
-		Patch:      diffmap.DiffMap{"foo": "baz"},
-	}
+	patch1 := &store.Patch{PreviousID: snap.ID, Patch: diffmap.DiffMap{"foo": "baz"}}
 	if err := s.SetPatch(ctx, id, patch1); err != nil {
 		t.Fatalf("set patch1: %v", err)
 	}
@@ -73,61 +177,46 @@ func TestSnapshotPatchRoundtrip(t *testing.T) {
 		t.Fatalf("patch1 should receive ID 1, got %d", patch1.ID)
 	}
 
-	// -------- patch #2 ----------------------------------------------------
-	patch2 := &store.Patch{
-		PreviousID: patch1.ID,
-		Patch:      diffmap.DiffMap{"bar": 42},
-	}
+	patch2 := &store.Patch{PreviousID: patch1.ID, Patch: diffmap.DiffMap{"bar": 42}}
 	_ = s.SetPatch(ctx, id, patch2)
 
-	// latest should now be 2
 	if latest, _ := s.GetLatestRevision(ctx, id); latest != 2 {
 		t.Fatalf("latest want 2, got %d", latest)
 	}
 
-	// -------- random gets -------------------------------------------------
-	// rev-0   -> snapshot
 	sn0, p0, err := s.Get(ctx, id, 0)
 	if err != nil || p0 != nil || sn0 == nil {
 		t.Fatalf("rev0: want snapshot, got %+v / %+v / err=%v", sn0, p0, err)
 	}
-	// rev-1   -> patch
 	sn1, p1, _ := s.Get(ctx, id, 1)
 	if sn1 != nil || p1 == nil || p1.ID != 1 {
 		t.Fatalf("rev1 not patch1")
 	}
-	// rev-2   -> patch
 	_, p2, _ := s.Get(ctx, id, 2)
 	if p2 == nil || p2.ID != 2 {
 		t.Fatalf("rev2 not patch2")
 	}
 }
 
-// TestConcurrentClaims ensures claimNextRevision is atomic.
 func TestConcurrentClaims(t *testing.T) {
-	dir := t.TempDir()
-	s, _ := New(filepath.Join(dir, "db.bb"), nil, false)
-	t.Cleanup(func() { _ = s.Close() })
+	s := openStore(t, Options{})
 
-	// race 20 goroutines
 	errs := make(chan error, 20)
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		go func() {
 			errs <- s.SetSnapshot(ctx, id, &store.Snapshot{Object: diffmap.DiffMap{"x": i}})
 		}()
 	}
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		if e := <-errs; e != nil {
 			t.Fatalf("concurrent SetSnapshot failed: %v", e)
 		}
 	}
-
 	if latest, _ := s.GetLatestRevision(ctx, id); latest != 19 {
 		t.Fatalf("after 20 writes, latest should be 19, got %d", latest)
 	}
 }
 
-// TestPersistedValues verifies that bytes written are real MessagePack.
 func TestPersistedValues(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "db.bb")
@@ -135,9 +224,1189 @@ func TestPersistedValues(t *testing.T) {
 	_ = s.SetSnapshot(ctx, id, &store.Snapshot{Object: diffmap.DiffMap{"k": "v"}})
 	_ = s.Close()
 
-	// reopen raw file and search for MessagePack prefix 0x81 (map of 1)
 	blob, _ := os.ReadFile(path)
 	if !bytes.Contains(blob, []byte{0x81}) {
 		t.Fatalf("file does not appear to contain msgpack map header")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Data integrity: write many revisions, read every one back, deep-compare.
+// Runs once for each store mode to catch pool/compression bugs.
+// ---------------------------------------------------------------------------
+
+func TestDataIntegrity(t *testing.T) {
+	modes := []struct {
+		name string
+		opts Options
+	}{
+		{"plain", Options{}},
+		{"compressed", Options{Compress: true}},
+		{"periodic_sync", Options{Durable: true, SyncInterval: 10 * time.Millisecond}},
+		{"periodic_sync_compressed", Options{Durable: true, SyncInterval: 10 * time.Millisecond, Compress: true}},
+	}
+
+	const revisions = 64
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			s := openStore(t, mode.opts)
+
+			// keep expected data to verify later
+			type entry struct {
+				isSnapshot bool
+				data       diffmap.DiffMap
+				prevID     store.RevisionID
+			}
+			expected := make([]entry, revisions)
+
+			for i := range revisions {
+				data := diffmap.DiffMap{
+					"index":  i,
+					"value":  strings.Repeat("v", i+1),
+					"nested": diffmap.DiffMap{"deep": float64(i) * 1.5},
+				}
+
+				if i%8 == 0 {
+					snap := &store.Snapshot{
+						Object: data,
+					}
+					if i > 0 {
+						snap.PreviousID = store.RevisionID(i - 1)
+					}
+					if err := s.SetSnapshot(ctx, id, snap); err != nil {
+						t.Fatalf("rev %d: set snapshot: %v", i, err)
+					}
+					if int(snap.ID) != i {
+						t.Fatalf("rev %d: ID want %d got %d", i, i, snap.ID)
+					}
+					expected[i] = entry{isSnapshot: true, data: data, prevID: snap.PreviousID}
+				} else {
+					p := &store.Patch{
+						PreviousID: store.RevisionID(i - 1),
+						Patch:      data,
+						Time:       time.Now(),
+					}
+					if err := s.SetPatch(ctx, id, p); err != nil {
+						t.Fatalf("rev %d: set patch: %v", i, err)
+					}
+					if int(p.ID) != i {
+						t.Fatalf("rev %d: ID want %d got %d", i, i, p.ID)
+					}
+					expected[i] = entry{isSnapshot: false, data: data, prevID: p.PreviousID}
+				}
+			}
+
+			// read back every revision and verify
+			for i, exp := range expected {
+				snap, patch, err := s.Get(ctx, id, store.RevisionID(i))
+				if err != nil {
+					t.Fatalf("rev %d: get: %v", i, err)
+				}
+
+				if exp.isSnapshot {
+					if snap == nil {
+						t.Fatalf("rev %d: expected snapshot, got patch", i)
+					}
+					if patch != nil {
+						t.Fatalf("rev %d: expected nil patch alongside snapshot", i)
+					}
+					if snap.ID != store.RevisionID(i) {
+						t.Fatalf("rev %d: snapshot ID = %d", i, snap.ID)
+					}
+					if snap.PreviousID != exp.prevID {
+						t.Fatalf("rev %d: snapshot PreviousID want %d got %d", i, exp.prevID, snap.PreviousID)
+					}
+					if !equalMaps(t, snap.Object, exp.data) {
+						t.Fatalf("rev %d: snapshot data mismatch", i)
+					}
+				} else {
+					if patch == nil {
+						t.Fatalf("rev %d: expected patch, got snapshot", i)
+					}
+					if snap != nil {
+						t.Fatalf("rev %d: expected nil snapshot alongside patch", i)
+					}
+					if patch.ID != store.RevisionID(i) {
+						t.Fatalf("rev %d: patch ID = %d", i, patch.ID)
+					}
+					if patch.PreviousID != exp.prevID {
+						t.Fatalf("rev %d: patch PreviousID want %d got %d", i, exp.prevID, patch.PreviousID)
+					}
+					if !equalMaps(t, patch.Patch, exp.data) {
+						t.Fatalf("rev %d: patch data mismatch", i)
+					}
+				}
+			}
+
+			// verify latest
+			latest, err := s.GetLatestRevision(ctx, id)
+			if err != nil {
+				t.Fatalf("get latest: %v", err)
+			}
+			if int(latest) != revisions-1 {
+				t.Fatalf("latest want %d got %d", revisions-1, latest)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pool safety under concurrent access: stresses all pooled buffers at once.
+// The race detector catches any cross-goroutine buffer corruption.
+// ---------------------------------------------------------------------------
+
+func TestPoolSafety_ConcurrentWriteRead(t *testing.T) {
+	modes := []struct {
+		name string
+		opts Options
+	}{
+		{"plain", Options{}},
+		{"compressed", Options{Compress: true}},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			s := openStore(t, mode.opts)
+
+			const objects = 8
+			const revisionsPerObject = 30
+			uids := make([]string, objects)
+			for i := range objects {
+				uids[i] = "uid-" + strconv.Itoa(i)
+			}
+
+			// concurrent writes
+			var wg sync.WaitGroup
+			for _, uid := range uids {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for j := range revisionsPerObject {
+						data := diffmap.DiffMap{
+							"obj":   uid,
+							"seq":   j,
+							"pad":   strings.Repeat("x", 100),
+							"inner": diffmap.DiffMap{"n": j},
+						}
+						if j == 0 {
+							err := s.SetSnapshot(ctx, uid, &store.Snapshot{Object: data})
+							if err != nil {
+								t.Errorf("snapshot %s/%d: %v", uid, j, err)
+							}
+						} else {
+							err := s.SetPatch(ctx, uid, &store.Patch{
+								PreviousID: store.RevisionID(j - 1),
+								Patch:      data,
+							})
+							if err != nil {
+								t.Errorf("patch %s/%d: %v", uid, j, err)
+							}
+						}
+					}
+				}()
+			}
+			wg.Wait()
+
+			// concurrent reads while more writes happen
+			var wg2 sync.WaitGroup
+			for _, uid := range uids {
+				// reader
+				wg2.Add(1)
+				go func() {
+					defer wg2.Done()
+					for j := range revisionsPerObject {
+						snap, patch, err := s.Get(ctx, uid, store.RevisionID(j))
+						if err != nil {
+							t.Errorf("get %s/%d: %v", uid, j, err)
+							return
+						}
+						if snap == nil && patch == nil {
+							t.Errorf("get %s/%d: both nil", uid, j)
+							return
+						}
+						// verify the data belongs to this object
+						var data diffmap.DiffMap
+						if snap != nil {
+							data = snap.Object
+						} else {
+							data = patch.Patch
+						}
+						if data["obj"] != uid {
+							t.Errorf("get %s/%d: wrong uid in data: %v", uid, j, data["obj"])
+						}
+					}
+				}()
+			}
+			wg2.Wait()
+
+			// verify all revisions for each object
+			for _, uid := range uids {
+				latest, err := s.GetLatestRevision(ctx, uid)
+				if err != nil {
+					t.Fatalf("latest for %s: %v", uid, err)
+				}
+				if int(latest) != revisionsPerObject-1 {
+					t.Fatalf("latest for %s: want %d got %d", uid, revisionsPerObject-1, latest)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Compression round-trip with various payload shapes.
+// Checks that s2 compression introduces no artifacts.
+// ---------------------------------------------------------------------------
+
+func TestCompression_PayloadShapes(t *testing.T) {
+	s := openStore(t, Options{Compress: true})
+
+	cases := []struct {
+		name string
+		data diffmap.DiffMap
+	}{
+		{"empty_map", diffmap.DiffMap{}},
+		{"single_key", diffmap.DiffMap{"a": "b"}},
+		{
+			"numeric_values", diffmap.DiffMap{
+				"int": 42, "int64": int64(math.MaxInt64), "float": 3.14,
+			},
+		},
+		{
+			"bool_and_nil", diffmap.DiffMap{
+				"yes": true, "no": false, "null": nil,
+			},
+		},
+		{
+			"deeply_nested", diffmap.DiffMap{
+				"l1": diffmap.DiffMap{
+					"l2": diffmap.DiffMap{
+						"l3": diffmap.DiffMap{
+							"l4": diffmap.DiffMap{"leaf": "deep"},
+						},
+					},
+				},
+			},
+		},
+		{
+			"large_string_value", diffmap.DiffMap{
+				"big": strings.Repeat("abcdef0123456789", 1000),
+			},
+		},
+		{
+			"many_keys", func() diffmap.DiffMap {
+				m := make(diffmap.DiffMap, 200)
+				for i := range 200 {
+					m["key-"+strconv.Itoa(i)] = strconv.Itoa(i)
+				}
+				return m
+			}(),
+		},
+		{
+			"mixed_types", diffmap.DiffMap{
+				"s": "hello", "i": 1, "i64": int64(2),
+				"f": 1.5, "b": true, "n": nil,
+				"m": diffmap.DiffMap{"x": "y"},
+			},
+		},
+		{
+			"repetitive_data", func() diffmap.DiffMap {
+				// highly compressible
+				m := make(diffmap.DiffMap, 50)
+				for i := range 50 {
+					m["k"+strconv.Itoa(i)] = "same-value-repeated"
+				}
+				return m
+			}(),
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			uid := "shape-" + strconv.Itoa(i)
+
+			// write as snapshot
+			snap := &store.Snapshot{Object: tc.data, Time: time.Now()}
+			if err := s.SetSnapshot(ctx, uid, snap); err != nil {
+				t.Fatalf("set snapshot: %v", err)
+			}
+
+			// write as patch
+			patch := &store.Patch{PreviousID: snap.ID, Patch: tc.data, Time: time.Now()}
+			if err := s.SetPatch(ctx, uid, patch); err != nil {
+				t.Fatalf("set patch: %v", err)
+			}
+
+			// read back snapshot
+			gotSnap, _, err := s.Get(ctx, uid, snap.ID)
+			if err != nil {
+				t.Fatalf("get snapshot: %v", err)
+			}
+			if !equalMaps(t, gotSnap.Object, tc.data) {
+				t.Fatalf("snapshot mismatch")
+			}
+
+			// read back patch
+			_, gotPatch, err := s.Get(ctx, uid, patch.ID)
+			if err != nil {
+				t.Fatalf("get patch: %v", err)
+			}
+			if !equalMaps(t, gotPatch.Patch, tc.data) {
+				t.Fatalf("patch mismatch")
+			}
+
+			// verify metadata survived
+			if gotSnap.ID != snap.ID {
+				t.Fatalf("snapshot ID: want %d got %d", snap.ID, gotSnap.ID)
+			}
+			if gotPatch.ID != patch.ID {
+				t.Fatalf("patch ID: want %d got %d", patch.ID, gotPatch.ID)
+			}
+			if gotPatch.PreviousID != patch.PreviousID {
+				t.Fatalf("patch PreviousID: want %d got %d", patch.PreviousID, gotPatch.PreviousID)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Multi-object key isolation: different UIDs must never cross-contaminate.
+// ---------------------------------------------------------------------------
+
+func TestMultiObjectIsolation(t *testing.T) {
+	modes := []struct {
+		name string
+		opts Options
+	}{
+		{"plain", Options{}},
+		{"compressed", Options{Compress: true}},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			s := openStore(t, mode.opts)
+
+			const objects = 10
+			const revisions = 16
+
+			// write unique data per object
+			for i := range objects {
+				uid := "obj-" + strconv.Itoa(i)
+				for j := range revisions {
+					data := diffmap.DiffMap{
+						"owner": uid,
+						"seq":   j,
+					}
+					if j == 0 {
+						_ = s.SetSnapshot(ctx, uid, &store.Snapshot{Object: data})
+					} else {
+						_ = s.SetPatch(ctx, uid, &store.Patch{
+							PreviousID: store.RevisionID(j - 1),
+							Patch:      data,
+						})
+					}
+				}
+			}
+
+			// verify isolation: every entry must contain the correct owner
+			for i := range objects {
+				uid := "obj-" + strconv.Itoa(i)
+				for j := range revisions {
+					snap, patch, err := s.Get(ctx, uid, store.RevisionID(j))
+					if err != nil {
+						t.Fatalf("get %s/%d: %v", uid, j, err)
+					}
+
+					var data diffmap.DiffMap
+					if snap != nil {
+						data = snap.Object
+					} else {
+						data = patch.Patch
+					}
+
+					if data["owner"] != uid {
+						t.Fatalf("cross-contamination: %s/%d has owner=%v", uid, j, data["owner"])
+					}
+					if gotSeq, ok := toFloat64(data["seq"]); !ok || gotSeq != float64(j) {
+						t.Fatalf("wrong seq: %s/%d has seq=%v", uid, j, data["seq"])
+					}
+				}
+
+				latest, _ := s.GetLatestRevision(ctx, uid)
+				if int(latest) != revisions-1 {
+					t.Fatalf("latest for %s: want %d got %d", uid, revisions-1, latest)
+				}
+			}
+
+			// walk and verify all entries
+			seen := map[string]int{}
+			err := s.WalkObjectRevisions(func(
+				uid string,
+				revID store.RevisionID,
+				snap *store.Snapshot,
+				patch *store.Patch,
+			) bool {
+				var data diffmap.DiffMap
+				if snap != nil {
+					data = snap.Object
+				} else {
+					data = patch.Patch
+				}
+				if data["owner"] != uid {
+					t.Errorf("walk: uid=%s rev=%d has owner=%v", uid, revID, data["owner"])
+				}
+				seen[uid]++
+				return true
+			})
+			if err != nil {
+				t.Fatalf("walk: %v", err)
+			}
+			if len(seen) != objects {
+				t.Fatalf("walk: expected %d objects, saw %d", objects, len(seen))
+			}
+			for uid, count := range seen {
+				if count != revisions {
+					t.Fatalf("walk: %s had %d revisions, want %d", uid, count, revisions)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DB persistence: close and reopen, verify data survives.
+// ---------------------------------------------------------------------------
+
+func TestPersistence_CloseReopen(t *testing.T) {
+	modes := []struct {
+		name string
+		opts Options
+	}{
+		{"plain", Options{}},
+		{"compressed", Options{Compress: true}},
+		{"periodic_sync", Options{Durable: true, SyncInterval: 10 * time.Millisecond}},
+		{"periodic_sync_compressed", Options{Durable: true, SyncInterval: 10 * time.Millisecond, Compress: true}},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "persist.bb")
+
+			// phase 1: write
+			s1, err := NewWithOptions(path, mode.opts)
+			if err != nil {
+				t.Fatalf("open phase 1: %v", err)
+			}
+
+			snap := &store.Snapshot{
+				Object: diffmap.DiffMap{"persistent": "data", "n": 42},
+				Time:   time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC),
+			}
+			if err := s1.SetSnapshot(ctx, id, snap); err != nil {
+				t.Fatalf("phase 1 snapshot: %v", err)
+			}
+
+			patch := &store.Patch{
+				PreviousID: snap.ID,
+				Patch:      diffmap.DiffMap{"n": 43},
+				Time:       time.Date(2025, 6, 15, 12, 1, 0, 0, time.UTC),
+			}
+			if err := s1.SetPatch(ctx, id, patch); err != nil {
+				t.Fatalf("phase 1 patch: %v", err)
+			}
+
+			// wait for a sync tick if periodic
+			if mode.opts.SyncInterval > 0 {
+				time.Sleep(mode.opts.SyncInterval * 2)
+			}
+			if err := s1.Close(); err != nil {
+				t.Fatalf("close phase 1: %v", err)
+			}
+
+			// phase 2: reopen and verify
+			s2, err := NewWithOptions(path, mode.opts)
+			if err != nil {
+				t.Fatalf("open phase 2: %v", err)
+			}
+			defer func() { _ = s2.Close() }()
+
+			latest, err := s2.GetLatestRevision(ctx, id)
+			if err != nil {
+				t.Fatalf("phase 2 latest: %v", err)
+			}
+			if latest != 1 {
+				t.Fatalf("phase 2 latest: want 1 got %d", latest)
+			}
+
+			gotSnap, _, err := s2.Get(ctx, id, 0)
+			if err != nil {
+				t.Fatalf("phase 2 get rev 0: %v", err)
+			}
+			if gotSnap.Object["persistent"] != "data" {
+				t.Fatalf("phase 2 snapshot data wrong: %v", gotSnap.Object)
+			}
+			if n, ok := toFloat64(gotSnap.Object["n"]); !ok || n != 42 {
+				t.Fatalf("phase 2 snapshot n: want 42 got %v", gotSnap.Object["n"])
+			}
+
+			_, gotPatch, err := s2.Get(ctx, id, 1)
+			if err != nil {
+				t.Fatalf("phase 2 get rev 1: %v", err)
+			}
+			if n, ok := toFloat64(gotPatch.Patch["n"]); !ok || n != 43 {
+				t.Fatalf("phase 2 patch n: want 43 got %v", gotPatch.Patch["n"])
+			}
+			if gotPatch.PreviousID != 0 {
+				t.Fatalf("phase 2 patch PreviousID: want 0 got %d", gotPatch.PreviousID)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Walk completeness: every entry returned by Walk matches individual Get.
+// ---------------------------------------------------------------------------
+
+func TestWalkMatchesGet(t *testing.T) {
+	modes := []struct {
+		name string
+		opts Options
+	}{
+		{"plain", Options{}},
+		{"compressed", Options{Compress: true}},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			s := openStore(t, mode.opts)
+
+			// write 3 objects, 10 revisions each (mix of snaps and patches)
+			for i := range 3 {
+				uid := "walk-" + strconv.Itoa(i)
+				for j := range 10 {
+					data := diffmap.DiffMap{"uid": uid, "j": j}
+					if j%5 == 0 {
+						_ = s.SetSnapshot(ctx, uid, &store.Snapshot{Object: data})
+					} else {
+						_ = s.SetPatch(ctx, uid, &store.Patch{
+							PreviousID: store.RevisionID(j - 1),
+							Patch:      data,
+						})
+					}
+				}
+			}
+
+			// walk and compare each entry with a direct Get
+			err := s.WalkObjectRevisions(func(
+				uid string,
+				revID store.RevisionID,
+				wSnap *store.Snapshot,
+				wPatch *store.Patch,
+			) bool {
+				gSnap, gPatch, err := s.Get(ctx, uid, revID)
+				if err != nil {
+					t.Errorf("Get(%s, %d) during walk: %v", uid, revID, err)
+					return false
+				}
+
+				// both should agree on type
+				if (wSnap != nil) != (gSnap != nil) {
+					t.Errorf("%s/%d: walk says snapshot=%v, Get says snapshot=%v", uid, revID, wSnap != nil, gSnap != nil)
+					return false
+				}
+				if (wPatch != nil) != (gPatch != nil) {
+					t.Errorf("%s/%d: walk says patch=%v, Get says patch=%v", uid, revID, wPatch != nil, gPatch != nil)
+					return false
+				}
+
+				if wSnap != nil {
+					if !equalMaps(t, wSnap.Object, gSnap.Object) {
+						t.Errorf("%s/%d: snapshot data mismatch", uid, revID)
+					}
+					if wSnap.ID != gSnap.ID || wSnap.PreviousID != gSnap.PreviousID {
+						t.Errorf("%s/%d: snapshot metadata mismatch", uid, revID)
+					}
+				}
+				if wPatch != nil {
+					if !equalMaps(t, wPatch.Patch, gPatch.Patch) {
+						t.Errorf("%s/%d: patch data mismatch", uid, revID)
+					}
+					if wPatch.ID != gPatch.ID || wPatch.PreviousID != gPatch.PreviousID {
+						t.Errorf("%s/%d: patch metadata mismatch", uid, revID)
+					}
+				}
+				return true
+			})
+			if err != nil {
+				t.Fatalf("walk error: %v", err)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases: empty maps, nil values, very long UIDs, missing revisions.
+// ---------------------------------------------------------------------------
+
+func TestEdgeCases(t *testing.T) {
+	t.Run("empty_diffmap", func(t *testing.T) {
+		s := openStore(t, Options{Compress: true})
+
+		snap := &store.Snapshot{Object: diffmap.DiffMap{}}
+		if err := s.SetSnapshot(ctx, id, snap); err != nil {
+			t.Fatalf("set: %v", err)
+		}
+		got, _, err := s.Get(ctx, id, 0)
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		if len(got.Object) != 0 {
+			t.Fatalf("expected empty map, got %v", got.Object)
+		}
+	})
+
+	t.Run("nil_patch_field", func(t *testing.T) {
+		s := openStore(t, Options{Compress: true})
+
+		snap := &store.Snapshot{Object: diffmap.DiffMap{"a": 1}}
+		_ = s.SetSnapshot(ctx, id, snap)
+
+		p := &store.Patch{PreviousID: 0, Patch: nil}
+		if err := s.SetPatch(ctx, id, p); err != nil {
+			t.Fatalf("set: %v", err)
+		}
+		_, got, err := s.Get(ctx, id, 1)
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		if len(got.Patch) != 0 {
+			t.Fatalf("expected nil/empty patch, got %v", got.Patch)
+		}
+	})
+
+	t.Run("very_long_uid", func(t *testing.T) {
+		s := openStore(t, Options{Compress: true})
+
+		longUID := strings.Repeat("a", 1000)
+		snap := &store.Snapshot{Object: diffmap.DiffMap{"uid": longUID}}
+		if err := s.SetSnapshot(ctx, longUID, snap); err != nil {
+			t.Fatalf("set: %v", err)
+		}
+		got, _, err := s.Get(ctx, longUID, 0)
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		if got.Object["uid"] != longUID {
+			t.Fatalf("UID mismatch after roundtrip")
+		}
+	})
+
+	t.Run("get_missing_revision", func(t *testing.T) {
+		s := openStore(t, Options{})
+		_, _, err := s.Get(ctx, "nonexistent", 999)
+		if !errors.Is(err, store.ErrNotFound) {
+			t.Fatalf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("get_latest_missing_object", func(t *testing.T) {
+		s := openStore(t, Options{})
+		_, err := s.GetLatestRevision(ctx, "nonexistent")
+		if !errors.Is(err, store.ErrNotFound) {
+			t.Fatalf("expected ErrNotFound, got %v", err)
+		}
+	})
+
+	t.Run("walk_empty_store", func(t *testing.T) {
+		s := openStore(t, Options{})
+		count := 0
+		err := s.WalkObjectRevisions(func(_ string, _ store.RevisionID, _ *store.Snapshot, _ *store.Patch) bool {
+			count++
+			return true
+		})
+		if err != nil {
+			t.Fatalf("walk error: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("expected 0 entries, got %d", count)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Codec pool correctness: rapid sequential marshal/unmarshal must not
+// produce cross-contamination between calls.
+// ---------------------------------------------------------------------------
+
+func TestCodecPoolCorrectness(t *testing.T) {
+	codec := store.DefaultCodec
+
+	type testCase struct {
+		snap store.Snapshot
+		pat  store.Patch
+	}
+
+	cases := make([]testCase, 50)
+	for i := range cases {
+		cases[i] = testCase{
+			snap: store.Snapshot{
+				ID:         store.RevisionID(i),
+				PreviousID: store.RevisionID(i + 100),
+				Object:     diffmap.DiffMap{"i": i, "s": strings.Repeat("x", i+1)},
+				Time:       time.Date(2025, 1, 1+i, 0, 0, 0, 0, time.UTC),
+			},
+			pat: store.Patch{
+				ID:         store.RevisionID(i + 1000),
+				PreviousID: store.RevisionID(i + 2000),
+				Patch:      diffmap.DiffMap{"p": i, "d": float64(i) * 0.1},
+				Time:       time.Date(2025, 6, 1+i, 0, 0, 0, 0, time.UTC),
+			},
+		}
+	}
+
+	// marshal all, then unmarshal all, verify no mixing
+	snapBytes := make([][]byte, len(cases))
+	patchBytes := make([][]byte, len(cases))
+	for i, tc := range cases {
+		var err error
+		snapBytes[i], err = codec.Marshal(&tc.snap)
+		if err != nil {
+			t.Fatalf("marshal snap %d: %v", i, err)
+		}
+		patchBytes[i], err = codec.Marshal(&tc.pat)
+		if err != nil {
+			t.Fatalf("marshal patch %d: %v", i, err)
+		}
+	}
+
+	for i, tc := range cases {
+		var gotSnap store.Snapshot
+		if err := codec.Unmarshal(snapBytes[i], &gotSnap); err != nil {
+			t.Fatalf("unmarshal snap %d: %v", i, err)
+		}
+		if gotSnap.ID != tc.snap.ID {
+			t.Fatalf("snap %d ID: want %d got %d", i, tc.snap.ID, gotSnap.ID)
+		}
+		if gotSnap.PreviousID != tc.snap.PreviousID {
+			t.Fatalf("snap %d PreviousID: want %d got %d", i, tc.snap.PreviousID, gotSnap.PreviousID)
+		}
+		if !equalMaps(t, gotSnap.Object, tc.snap.Object) {
+			t.Fatalf("snap %d Object mismatch", i)
+		}
+
+		var gotPatch store.Patch
+		if err := codec.Unmarshal(patchBytes[i], &gotPatch); err != nil {
+			t.Fatalf("unmarshal patch %d: %v", i, err)
+		}
+		if gotPatch.ID != tc.pat.ID {
+			t.Fatalf("patch %d ID: want %d got %d", i, tc.pat.ID, gotPatch.ID)
+		}
+		if !equalMaps(t, gotPatch.Patch, tc.pat.Patch) {
+			t.Fatalf("patch %d Patch mismatch", i)
+		}
+	}
+}
+
+// TestCodecPoolConcurrency fires many goroutines doing marshal+unmarshal
+// on different data to check for pool cross-contamination under contention.
+func TestCodecPoolConcurrency(t *testing.T) {
+	codec := store.DefaultCodec
+	const goroutines = 16
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range iterations {
+				unique := g*iterations + i
+				snap := store.Snapshot{
+					ID:     store.RevisionID(unique),
+					Object: diffmap.DiffMap{"g": g, "i": i, "u": unique},
+				}
+				data, err := codec.Marshal(&snap)
+				if err != nil {
+					t.Errorf("g%d i%d: marshal: %v", g, i, err)
+					return
+				}
+				var got store.Snapshot
+				if err := codec.Unmarshal(data, &got); err != nil {
+					t.Errorf("g%d i%d: unmarshal: %v", g, i, err)
+					return
+				}
+				if got.ID != snap.ID {
+					t.Errorf("g%d i%d: ID want %d got %d", g, i, snap.ID, got.ID)
+					return
+				}
+				if !equalMaps(t, got.Object, snap.Object) {
+					t.Errorf("g%d i%d: Object mismatch: got %v want %v", g, i, got.Object, snap.Object)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// Periodic sync mode: verify writes are actually persisted to disk.
+// ---------------------------------------------------------------------------
+
+func TestPeriodicSync_DataPersists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sync.bb")
+
+	s, err := NewWithOptions(path, Options{
+		Durable:      true,
+		SyncInterval: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	// write some data
+	for i := range 20 {
+		_ = s.SetPatch(ctx, id, &store.Patch{
+			PreviousID: store.RevisionID(i),
+			Patch:      diffmap.DiffMap{"val": i},
+		})
+	}
+
+	// wait for sync to happen
+	time.Sleep(30 * time.Millisecond)
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// reopen and verify
+	s2, err := NewWithOptions(path, Options{
+		Durable:      true,
+		SyncInterval: 10 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = s2.Close() }()
+
+	latest, err := s2.GetLatestRevision(ctx, id)
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	if latest != 19 {
+		t.Fatalf("latest: want 19 got %d", latest)
+	}
+
+	// spot check a few values
+	for _, rev := range []int{0, 5, 10, 19} {
+		_, p, err := s2.Get(ctx, id, store.RevisionID(rev))
+		if err != nil {
+			t.Fatalf("get rev %d: %v", rev, err)
+		}
+		if p == nil {
+			t.Fatalf("rev %d: expected patch", rev)
+		}
+		if v, ok := toFloat64(p.Patch["val"]); !ok || v != float64(rev) {
+			t.Fatalf("rev %d: val want %d got %v", rev, rev, p.Patch["val"])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Compressed store: verify DB is actually smaller than uncompressed.
+// ---------------------------------------------------------------------------
+
+func TestCompression_ReducesSize(t *testing.T) {
+	dir := t.TempDir()
+	pathPlain := filepath.Join(dir, "plain.bb")
+	pathComp := filepath.Join(dir, "compressed.bb")
+
+	write := func(path string, compress bool) {
+		s, err := NewWithOptions(path, Options{Compress: compress})
+		if err != nil {
+			t.Fatalf("open %s: %v", path, err)
+		}
+		// write highly compressible data
+		for i := range 50 {
+			data := diffmap.DiffMap{
+				"kind":       "ConfigMap",
+				"apiVersion": "v1",
+				"metadata": diffmap.DiffMap{
+					"name":      "my-config-" + strconv.Itoa(i),
+					"namespace": "default",
+					"uid":       "uid-" + strconv.Itoa(i),
+				},
+				"data": diffmap.DiffMap{
+					"config.yaml": strings.Repeat("key: value\n", 50),
+				},
+			}
+			_ = s.SetSnapshot(ctx, "uid-"+strconv.Itoa(i), &store.Snapshot{Object: data})
+		}
+		_ = s.Close()
+	}
+
+	write(pathPlain, false)
+	write(pathComp, true)
+
+	plainInfo, _ := os.Stat(pathPlain)
+	compInfo, _ := os.Stat(pathComp)
+
+	if compInfo.Size() >= plainInfo.Size() {
+		t.Fatalf("compressed (%d bytes) should be smaller than plain (%d bytes)",
+			compInfo.Size(), plainInfo.Size())
+	}
+
+	ratio := float64(plainInfo.Size()) / float64(compInfo.Size())
+	t.Logf("compression ratio: %.1fx (%d bytes -> %d bytes)", ratio, plainInfo.Size(), compInfo.Size())
+}
+
+// == Benchmarks ============================================================
+
+func benchStoreOpts(b *testing.B, opts Options) *Store {
+	b.Helper()
+	s, err := NewWithOptions(filepath.Join(b.TempDir(), "bench.bb"), opts)
+	if err != nil {
+		b.Fatalf("open: %v", err)
+	}
+	b.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func benchStore(b *testing.B, durable bool) *Store {
+	b.Helper()
+	return benchStoreOpts(b, Options{Durable: durable})
+}
+
+func largePatch() *store.Patch {
+	m := make(diffmap.DiffMap, 20)
+	for i := range 20 {
+		m["field-"+strconv.Itoa(i)] = strings.Repeat("x", 50)
+	}
+	return &store.Patch{PreviousID: 0, Patch: m, Time: time.Now()}
+}
+
+func largeSnapshot() *store.Snapshot {
+	m := make(diffmap.DiffMap, 500)
+	for i := range 500 {
+		v := strings.Repeat(string(rune(i%26+65)), 26)
+		m[v] = v
+	}
+	return &store.Snapshot{PreviousID: 0, Object: m, Time: time.Now()}
+}
+
+func BenchmarkMarshalPatch(b *testing.B) {
+	p := largePatch()
+	codec := store.DefaultCodec
+	for range b.N {
+		if _, err := codec.Marshal(p); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshalSnapshot(b *testing.B) {
+	s := largeSnapshot()
+	codec := store.DefaultCodec
+	for range b.N {
+		if _, err := codec.Marshal(s); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalPatch(b *testing.B) {
+	p := largePatch()
+	codec := store.DefaultCodec
+	data, _ := codec.Marshal(p)
+	for range b.N {
+		var out store.Patch
+		if err := codec.Unmarshal(data, &out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalSnapshot(b *testing.B) {
+	s := largeSnapshot()
+	codec := store.DefaultCodec
+	data, _ := codec.Marshal(s)
+	for range b.N {
+		var out store.Snapshot
+		if err := codec.Unmarshal(data, &out); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkKeyObjectRevision(b *testing.B) {
+	uid := "550e8400-e29b-41d4-a716-446655440000"
+	for range b.N {
+		_ = keyObjectRevision(uid, 12345)
+	}
+}
+
+func BenchmarkSetPatch(b *testing.B) {
+	s := benchStore(b, false)
+	p := largePatch()
+	for range b.N {
+		p.ID = 0
+		if err := s.SetPatch(ctx, id, p); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSetPatch_Compressed(b *testing.B) {
+	s := benchStoreOpts(b, Options{Compress: true})
+	p := largePatch()
+	for range b.N {
+		p.ID = 0
+		if err := s.SetPatch(ctx, id, p); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSetPatch_Durable(b *testing.B) {
+	s := benchStore(b, true)
+	p := largePatch()
+	for range b.N {
+		p.ID = 0
+		if err := s.SetPatch(ctx, id, p); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSetPatch_PeriodicSync(b *testing.B) {
+	s := benchStoreOpts(b, Options{Durable: true, SyncInterval: 50 * time.Millisecond})
+	p := largePatch()
+	for range b.N {
+		p.ID = 0
+		if err := s.SetPatch(ctx, id, p); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSetPatch_PeriodicSyncCompressed(b *testing.B) {
+	s := benchStoreOpts(b, Options{Durable: true, SyncInterval: 50 * time.Millisecond, Compress: true})
+	p := largePatch()
+	for range b.N {
+		p.ID = 0
+		if err := s.SetPatch(ctx, id, p); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSetSnapshot(b *testing.B) {
+	s := benchStore(b, false)
+	snap := largeSnapshot()
+	for range b.N {
+		snap.ID = 0
+		if err := s.SetSnapshot(ctx, id, snap); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSetSnapshot_Compressed(b *testing.B) {
+	s := benchStoreOpts(b, Options{Compress: true})
+	snap := largeSnapshot()
+	for range b.N {
+		snap.ID = 0
+		if err := s.SetSnapshot(ctx, id, snap); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGet(b *testing.B) {
+	s := benchStore(b, false)
+	for range 100 {
+		if err := s.SetPatch(ctx, id, largePatch()); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ResetTimer()
+	for i := range b.N {
+		rev := store.RevisionID(i % 100)
+		if _, _, err := s.Get(ctx, id, rev); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGet_Compressed(b *testing.B) {
+	s := benchStoreOpts(b, Options{Compress: true})
+	for range 100 {
+		if err := s.SetPatch(ctx, id, largePatch()); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ResetTimer()
+	for i := range b.N {
+		rev := store.RevisionID(i % 100)
+		if _, _, err := s.Get(ctx, id, rev); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGetLatestRevision(b *testing.B) {
+	s := benchStore(b, false)
+	_ = s.SetPatch(ctx, id, largePatch())
+	b.ResetTimer()
+	for range b.N {
+		_, _ = s.GetLatestRevision(ctx, id)
+	}
+}
+
+func BenchmarkWalkObjectRevisions(b *testing.B) {
+	s := benchStore(b, false)
+	for range 200 {
+		if err := s.SetPatch(ctx, id, largePatch()); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.ResetTimer()
+	for range b.N {
+		_ = s.WalkObjectRevisions(func(_ string, _ store.RevisionID, _ *store.Snapshot, _ *store.Patch) bool {
+			return true
+		})
+	}
+}
+
+func BenchmarkFileSize(b *testing.B) {
+	const writes = 200
+
+	run := func(name string, opts Options) {
+		b.Run(name, func(b *testing.B) {
+			for range b.N {
+				dir := b.TempDir()
+				path := filepath.Join(dir, "bench.bb")
+				s, err := NewWithOptions(path, opts)
+				if err != nil {
+					b.Fatal(err)
+				}
+				for i := range writes {
+					if i%8 == 0 {
+						_ = s.SetSnapshot(ctx, id, largeSnapshot())
+					} else {
+						_ = s.SetPatch(ctx, id, largePatch())
+					}
+				}
+				_ = s.Close()
+				if fi, err := os.Stat(path); err == nil {
+					b.ReportMetric(float64(fi.Size())/1024, "KB_db")
+				}
+			}
+		})
+	}
+
+	run("plain", Options{})
+	run("compressed", Options{Compress: true})
 }

--- a/internal/store/codec.go
+++ b/internal/store/codec.go
@@ -1,27 +1,56 @@
 package store
 
-import "github.com/vmihailenco/msgpack/v5"
+import (
+	"bytes"
+	"sync"
+
+	"github.com/vmihailenco/msgpack/v5"
+)
 
 // Codec is an interface for encoding and decoding data.
-// It is used to abstract away the underlying serialization format.
-// This allows for flexibility in choosing the serialization format without changing the implementation of the store.
-// The default codec is MessagePack, but other codecs can be implemented as needed. :)
 type Codec interface {
-	// Marshal encodes the given value into a byte slice.
 	Marshal(v any) ([]byte, error)
-	// Unmarshal decodes the given byte slice into the provided value.
 	Unmarshal(data []byte, v any) error
 }
 
-// DefaultCodec is MessagePack.
-var DefaultCodec Codec = msgpackCodec{}
+// DefaultCodec is a pooled MessagePack codec that reuses encoder/decoder
+// objects and their underlying buffers across calls.
+var DefaultCodec Codec = &pooledMsgpackCodec{}
 
-type msgpackCodec struct{}
-
-func (msgpackCodec) Marshal(v any) ([]byte, error) {
-	return msgpack.Marshal(v)
+var bufPool = sync.Pool{
+	New: func() any {
+		return bytes.NewBuffer(make([]byte, 0, 1024))
+	},
 }
 
-func (msgpackCodec) Unmarshal(b []byte, v any) error {
-	return msgpack.Unmarshal(b, v)
+type pooledMsgpackCodec struct{}
+
+func (pooledMsgpackCodec) Marshal(v any) ([]byte, error) {
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+
+	enc := msgpack.GetEncoder()
+	enc.Reset(buf)
+
+	err := enc.Encode(v)
+	msgpack.PutEncoder(enc)
+
+	if err != nil {
+		bufPool.Put(buf)
+		return nil, err
+	}
+
+	// Copy out so the pooled buffer can be reused immediately.
+	out := make([]byte, buf.Len())
+	copy(out, buf.Bytes())
+	bufPool.Put(buf)
+	return out, nil
+}
+
+func (pooledMsgpackCodec) Unmarshal(data []byte, v any) error {
+	dec := msgpack.GetDecoder()
+	dec.Reset(bytes.NewReader(data))
+	err := dec.Decode(v)
+	msgpack.PutDecoder(dec)
+	return err
 }

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -14,29 +14,25 @@ func (id RevisionID) String() string {
 }
 
 type Patch struct {
-	/// Revision Metadata
-	// ID of the revision
+	// ID is the revision identifier for this patch.
 	ID RevisionID `msgpack:"i" json:"ID,omitempty"`
 	// PreviousID is the ID of the previous revision.
 	// This should always be set since a patch cannot exist without a previous snapshot.
 	PreviousID RevisionID `msgpack:"<,omitempty" json:"previousID,omitempty"`
 
-	/// Patch Metadata
-	// Patch is an object with the diff between the previous revision and this revision.
-	// see [diffmap.Diff] for more details.
+	// Patch is the diff between the previous revision and this revision.
+	// See [diffmap.Diff] for more details.
 	Patch diffmap.DiffMap `msgpack:"s" json:"patch,omitempty"`
-	Time  time.Time       `msgpack:"t" json:"time,omitempty"`
+	Time  time.Time       `msgpack:"t" json:"time"`
 }
 
 type Snapshot struct {
-	/// Revision Metadata
-	// ID of the revision
+	// ID is the revision identifier for this snapshot.
 	ID RevisionID `msgpack:"i" json:"ID,omitempty"`
 	// PreviousID is the ID of the previous revision. This can be empty if this is the first revision.
 	PreviousID RevisionID `msgpack:"<,omitempty" json:"previousID,omitempty"`
 
-	/// Snapshot Metadata
-	// Object is the actual object being stored in this revision.
+	// Object is the full resource state stored in this revision.
 	Object diffmap.DiffMap `msgpack:"o" json:"object,omitempty"`
-	Time   time.Time       `msgpack:"t" json:"time,omitempty"`
+	Time   time.Time       `msgpack:"t" json:"time"`
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,3 +1,5 @@
+// Package store defines the persistence interfaces and model types for
+// storing Kubernetes resource revisions as snapshots and patches.
 package store
 
 import (


### PR DESCRIPTION
## Summary
- Replaces stateless msgpack codec with `sync.Pool`-backed `pooledMsgpackCodec` to reduce per-encode/decode allocations
- Adds S2 compression (`klauspost/compress`) for stored payloads, reducing DB file size
- Adds pooled key construction buffers in bbolt helpers
- Modernizes `splitObjectRevisionKey` to use `bytes.Cut`
- Adds `--no-compress` CLI flag to disable compression when CPU is scarce
- Expands bbolt store test suite from ~38 to ~1,345 lines

## Why
Performance and storage efficiency improvements to the persistence layer. The pooled codec avoids allocations on the hot path, and S2 compression significantly reduces DB file size with minimal CPU overhead.

## Stack
This is **PR 2 of 7** in the v2 series.
`v2` ← 01-dependency-upgrades ← **02-store-improvements** ← 03-pkg-mux ← 04-diffmap-diffpreview ← 05-domain-types ← 06-new-tui ← 07-simulation