### PR TITLE
feat: add simulation mode for development without a cluster

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -29,6 +30,7 @@ import (
 	"github.com/loog-project/loog/internal/adapter"
 	"github.com/loog-project/loog/internal/resource"
 	"github.com/loog-project/loog/internal/service"
+	"github.com/loog-project/loog/internal/simulation"
 	"github.com/loog-project/loog/internal/store"
 	bboltStore "github.com/loog-project/loog/internal/store/bbolt"
 	"github.com/loog-project/loog/internal/tui"
@@ -52,6 +54,7 @@ var (
 	snapshotInterval uint64
 	filterExpr       string
 	headlessMode     bool
+	simulateMode     bool
 )
 
 var rootCmd = &cobra.Command{
@@ -106,6 +109,8 @@ func init() {
 		"Disable s2 compression for stored payloads (larger DB but slightly less CPU)")
 	rootCmd.Flags().Uint64VarP(&snapshotInterval, "snapshot-interval", "s", 8,
 		"Create a full snapshot after this many patches (default 8)")
+	rootCmd.Flags().BoolVar(&simulateMode, "simulate", false,
+		"Run with simulated data instead of connecting to Kubernetes")
 
 	// allow some flags to be set via environment variables / config file
 	mustBind("kubeconfig",
@@ -152,6 +157,11 @@ func initConfig() {
 // run is the main entry point for the command execution.
 func run(ctx context.Context, args []string) error {
 	setupDebugLogger()
+
+	// Simulate mode: skip Kubernetes entirely, use simulated data
+	if simulateMode {
+		return runSimulateMode()
+	}
 
 	// Production mode: connect to Kubernetes
 	cleanup, prog, trackerService, rps, m, err := setupProduction(ctx, args)
@@ -202,6 +212,31 @@ func setupDebugLogger() {
 	} else {
 		log.Logger = zerolog.Nop()
 	}
+}
+
+// runSimulateMode starts the TUI with simulated data.
+func runSimulateMode() error {
+	setupLog.Info().Msg("Running in simulate mode with generated data")
+
+	klog.SetOutput(io.Discard)
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		return fmt.Errorf("cannot open %s: %w", os.DevNull, err)
+	}
+	defer func(devNull *os.File) {
+		_ = devNull.Close()
+	}(devNull)
+	savedStderr := os.Stderr
+	os.Stderr = devNull
+	defer func() { os.Stderr = savedStderr }()
+
+	simStore := simulation.New()
+	app := tui.NewApp(simStore, tui.WithSimulator(simStore))
+	p := tea.NewProgram(app, tea.WithAltScreen())
+	if _, err := p.Run(); err != nil {
+		setupLog.Error().Err(err).Msg("Error running TUI program")
+	}
+	return nil
 }
 
 // setupProduction initializes the output file, filter, store, kube client, and mux.
@@ -625,6 +660,11 @@ func loadHistoryFromDB(
 }
 
 func validateArgsAndFlags(_ *cobra.Command, args []string) error {
+	// Simulate mode doesn't need resource args or output file
+	if simulateMode {
+		return nil
+	}
+
 	if len(args) == 0 && outputFile == "" {
 		return fmt.Errorf(
 			"at least one resource argument or the --output flag must be provided (you may provide both)")

--- a/internal/simulation/simulation.go
+++ b/internal/simulation/simulation.go
@@ -1,0 +1,773 @@
+// Package simulation provides simulated Kubernetes resource data for the TUI.
+// It creates realistic resource histories with various scenarios (rollouts, CrashLoopBackOff,
+// operator reconcile bursts, reconcile loops, configuration drift) and provides live
+// simulation via tea.Cmd that generates new revisions at random intervals.
+//
+// The package provides a Store (implementing tui.Store) and a Simulator (implementing
+// tui.Simulator). Use New() to create a fully-populated Store, then pass it to
+// tui.NewApp() with tui.WithSimulator().
+package simulation
+
+import (
+	"sort"
+	"time"
+
+	"github.com/loog-project/loog/internal/resource"
+)
+
+// New creates a realistic set of Kubernetes resources with revision histories
+// for the --simulate mode. The returned Store implements tui.Store and tui.Simulator.
+func New() *Store {
+	now := time.Now()
+	resources := make(map[string]*resource.Data)
+
+	addResource := func(uid, kind, name, ns string, starred bool, revisions []resource.Revision) {
+		resources[uid] = &resource.Data{
+			Resource: resource.Resource{
+				UID:       uid,
+				Kind:      kind,
+				Name:      name,
+				Namespace: ns,
+				Starred:   starred,
+			},
+			Revisions: revisions,
+		}
+	}
+
+	addResource("uid-pod-nginx-1", "Pod", "nginx-7d4f8b-abc12", "default", true, []resource.Revision{
+		{
+			ID: 0x0001, EventType: resource.EventAdded, Time: now.Add(-12 * time.Minute), Object: map[string]any{
+				"apiVersion": "v1", "kind": "Pod",
+				"metadata": map[string]any{
+					"name": "nginx-7d4f8b-abc12", "namespace": "default", "uid": "uid-pod-nginx-1",
+					"labels":          map[string]any{"app": "nginx", "pod-template-hash": "7d4f8b"},
+					"ownerReferences": []any{map[string]any{"kind": "ReplicaSet", "name": "nginx-deployment-7d4f8b"}},
+				},
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":  "nginx",
+							"image": "nginx:1.24",
+							"ports": []any{map[string]any{"containerPort": float64(80)}},
+						},
+					},
+				},
+				"status": map[string]any{"phase": "Pending", "conditions": []any{}},
+			},
+		},
+		{
+			ID:         0x0003,
+			PreviousID: 0x0001,
+			EventType:  resource.EventModified,
+			Time:       now.Add(-11 * time.Minute),
+			Object: map[string]any{
+				"apiVersion": "v1", "kind": "Pod",
+				"metadata": map[string]any{
+					"name": "nginx-7d4f8b-abc12", "namespace": "default", "uid": "uid-pod-nginx-1",
+					"labels": map[string]any{"app": "nginx", "pod-template-hash": "7d4f8b"},
+				},
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":  "nginx",
+							"image": "nginx:1.24",
+							"ports": []any{map[string]any{"containerPort": float64(80)}},
+						},
+					},
+				},
+				"status": map[string]any{
+					"phase":      "Running",
+					"podIP":      "10.0.1.15",
+					"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+				},
+			},
+			Patch: map[string]any{"status": map[string]any{"phase": "Running", "podIP": "10.0.1.15"}},
+		},
+		{
+			ID:         0x000a,
+			PreviousID: 0x0003,
+			EventType:  resource.EventModified,
+			Time:       now.Add(-3 * time.Minute),
+			Object: map[string]any{
+				"apiVersion": "v1", "kind": "Pod",
+				"metadata": map[string]any{
+					"name": "nginx-7d4f8b-abc12", "namespace": "default", "uid": "uid-pod-nginx-1",
+					"labels": map[string]any{"app": "nginx", "pod-template-hash": "7d4f8b"},
+				},
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":  "nginx",
+							"image": "nginx:1.25",
+							"ports": []any{map[string]any{"containerPort": float64(80)}},
+						},
+					},
+				},
+				"status": map[string]any{
+					"phase":      "Running",
+					"podIP":      "10.0.1.15",
+					"conditions": []any{map[string]any{"type": "Ready", "status": "True"}},
+				},
+			},
+			Patch: map[string]any{"spec": map[string]any{"containers": []any{map[string]any{"image": "nginx:1.25"}}}},
+		},
+	})
+
+	addResource("uid-pod-nginx-2", "Pod", "nginx-7d4f8b-def34", "default", false, []resource.Revision{
+		{
+			ID: 0x0002, EventType: resource.EventAdded, Time: now.Add(-12 * time.Minute), Object: map[string]any{
+				"apiVersion": "v1", "kind": "Pod",
+				"metadata": map[string]any{"name": "nginx-7d4f8b-def34", "namespace": "default"},
+				"spec":     map[string]any{"containers": []any{map[string]any{"name": "nginx", "image": "nginx:1.24"}}},
+				"status":   map[string]any{"phase": "Pending"},
+			},
+		},
+		{
+			ID:         0x0004,
+			PreviousID: 0x0002,
+			EventType:  resource.EventModified,
+			Time:       now.Add(-11 * time.Minute),
+			Object: map[string]any{
+				"apiVersion": "v1", "kind": "Pod",
+				"metadata": map[string]any{"name": "nginx-7d4f8b-def34", "namespace": "default"},
+				"spec":     map[string]any{"containers": []any{map[string]any{"name": "nginx", "image": "nginx:1.24"}}},
+				"status":   map[string]any{"phase": "Running", "podIP": "10.0.1.16"},
+			},
+			Patch: map[string]any{"status": map[string]any{"phase": "Running", "podIP": "10.0.1.16"}},
+		},
+	})
+
+	addResource("uid-pod-nginx-3", "Pod", "nginx-7d4f8b-ghi56", "default", false, []resource.Revision{
+		{
+			ID: 0x0005, EventType: resource.EventAdded, Time: now.Add(-10 * time.Minute), Object: map[string]any{
+				"apiVersion": "v1", "kind": "Pod",
+				"metadata": map[string]any{"name": "nginx-7d4f8b-ghi56", "namespace": "default"},
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":      "nginx",
+							"image":     "nginx:1.24",
+							"resources": map[string]any{"limits": map[string]any{"memory": "64Mi"}},
+						},
+					},
+				},
+				"status": map[string]any{"phase": "Running"},
+			},
+		},
+		{
+			ID:         0x0008,
+			PreviousID: 0x0005,
+			EventType:  resource.EventModified,
+			Time:       now.Add(-7 * time.Minute),
+			Object: map[string]any{
+				"apiVersion": "v1", "kind": "Pod",
+				"metadata": map[string]any{"name": "nginx-7d4f8b-ghi56", "namespace": "default"},
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":      "nginx",
+							"image":     "nginx:1.24",
+							"resources": map[string]any{"limits": map[string]any{"memory": "64Mi"}},
+						},
+					},
+				},
+				"status": map[string]any{
+					"phase": "Running",
+					"containerStatuses": []any{
+						map[string]any{
+							"name": "nginx",
+							"state": map[string]any{
+								"terminated": map[string]any{
+									"reason":   "OOMKilled",
+									"exitCode": float64(137),
+								},
+							},
+						},
+					},
+				},
+			},
+			Patch: map[string]any{"status": map[string]any{"containerStatuses": []any{map[string]any{"state": map[string]any{"terminated": map[string]any{"reason": "OOMKilled"}}}}}},
+		},
+		{
+			ID:         0x0009,
+			PreviousID: 0x0008,
+			EventType:  resource.EventModified,
+			Time:       now.Add(-6 * time.Minute),
+			Object: map[string]any{
+				"apiVersion": "v1", "kind": "Pod",
+				"metadata": map[string]any{"name": "nginx-7d4f8b-ghi56", "namespace": "default"},
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":      "nginx",
+							"image":     "nginx:1.24",
+							"resources": map[string]any{"limits": map[string]any{"memory": "64Mi"}},
+						},
+					},
+				},
+				"status": map[string]any{
+					"phase": "Running",
+					"containerStatuses": []any{
+						map[string]any{
+							"name":         "nginx",
+							"restartCount": float64(1),
+							"state":        map[string]any{"running": map[string]any{}},
+						},
+					},
+				},
+			},
+			Patch: map[string]any{
+				"status": map[string]any{
+					"containerStatuses": []any{
+						map[string]any{
+							"restartCount": float64(1),
+							"state":        map[string]any{"running": map[string]any{}},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	addResource("uid-deploy-nginx", "Deployment", "nginx-deployment", "default", true, []resource.Revision{
+		{
+			ID: 0x0006, EventType: resource.EventAdded, Time: now.Add(-13 * time.Minute), Object: map[string]any{
+				"apiVersion": "apps/v1", "kind": "Deployment",
+				"metadata": map[string]any{"name": "nginx-deployment", "namespace": "default"},
+				"spec": map[string]any{
+					"replicas": float64(1),
+					"selector": map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "nginx",
+									"image": "nginx:1.24",
+								},
+							},
+						},
+					},
+				},
+				"status": map[string]any{"readyReplicas": float64(0), "replicas": float64(1)},
+			},
+		},
+		{
+			ID:         0x0007,
+			PreviousID: 0x0006,
+			EventType:  resource.EventModified,
+			Time:       now.Add(-11 * time.Minute),
+			Object: map[string]any{
+				"apiVersion": "apps/v1", "kind": "Deployment",
+				"metadata": map[string]any{"name": "nginx-deployment", "namespace": "default"},
+				"spec": map[string]any{
+					"replicas": float64(3),
+					"selector": map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "nginx",
+									"image": "nginx:1.24",
+								},
+							},
+						},
+					},
+				},
+				"status": map[string]any{"readyReplicas": float64(3), "replicas": float64(3)},
+			},
+			Patch: map[string]any{
+				"spec":   map[string]any{"replicas": float64(3)},
+				"status": map[string]any{"readyReplicas": float64(3), "replicas": float64(3)},
+			},
+		},
+		{
+			ID:         0x000b,
+			PreviousID: 0x0007,
+			EventType:  resource.EventModified,
+			Time:       now.Add(-3 * time.Minute),
+			Object: map[string]any{
+				"apiVersion": "apps/v1", "kind": "Deployment",
+				"metadata": map[string]any{"name": "nginx-deployment", "namespace": "default"},
+				"spec": map[string]any{
+					"replicas": float64(3),
+					"selector": map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "nginx",
+									"image": "nginx:1.25",
+								},
+							},
+						},
+					},
+				},
+				"status": map[string]any{
+					"readyReplicas":   float64(3),
+					"replicas":        float64(3),
+					"updatedReplicas": float64(3),
+				},
+			},
+			Patch: map[string]any{"spec": map[string]any{"template": map[string]any{"spec": map[string]any{"containers": []any{map[string]any{"image": "nginx:1.25"}}}}}},
+		},
+	})
+
+	addResource("uid-svc-nginx", "Service", "nginx-svc", "default", false, []resource.Revision{
+		{
+			ID: 0x000c, EventType: resource.EventAdded, Time: now.Add(-13 * time.Minute), Object: map[string]any{
+				"apiVersion": "v1", "kind": "Service",
+				"metadata": map[string]any{"name": "nginx-svc", "namespace": "default"},
+				"spec": map[string]any{
+					"type":     "ClusterIP",
+					"ports":    []any{map[string]any{"port": float64(80), "targetPort": float64(80)}},
+					"selector": map[string]any{"app": "nginx"},
+				},
+			},
+		},
+		{
+			ID:         0x000d,
+			PreviousID: 0x000c,
+			EventType:  resource.EventModified,
+			Time:       now.Add(-2 * time.Minute),
+			Object: map[string]any{
+				"apiVersion": "v1", "kind": "Service",
+				"metadata": map[string]any{"name": "nginx-svc", "namespace": "default"},
+				"spec": map[string]any{
+					"type":     "ClusterIP",
+					"ports":    []any{map[string]any{"port": float64(8080), "targetPort": float64(80)}},
+					"selector": map[string]any{"app": "nginx"},
+				},
+			},
+			Patch: map[string]any{"spec": map[string]any{"ports": []any{map[string]any{"port": float64(8080)}}}},
+		},
+	})
+
+	addResource("uid-cm-nginx", "ConfigMap", "nginx-config", "default", false, []resource.Revision{
+		{
+			ID: 0x000e, EventType: resource.EventAdded, Time: now.Add(-13 * time.Minute), Object: map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "nginx-config", "namespace": "default"},
+				"data":     map[string]any{"nginx.conf": "server { listen 80; }"},
+			},
+		},
+		{
+			ID:         0x000f,
+			PreviousID: 0x000e,
+			EventType:  resource.EventModified,
+			Time:       now.Add(-5 * time.Minute),
+			Object: map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "nginx-config", "namespace": "default"},
+				"data": map[string]any{
+					"nginx.conf": "server { listen 80; gzip on; }",
+					"extra.conf": "# extra config",
+				},
+			},
+			Patch: map[string]any{
+				"data": map[string]any{
+					"nginx.conf": "server { listen 80; gzip on; }",
+					"extra.conf": "# extra config",
+				},
+			},
+		},
+	})
+
+	addResource("uid-pod-api", "Pod", "api-server-6b7c-xyz99", "default", false, []resource.Revision{
+		{
+			ID: 0x0010, EventType: resource.EventAdded, Time: now.Add(-15 * time.Minute), Object: map[string]any{
+				"apiVersion": "v1", "kind": "Pod",
+				"metadata": map[string]any{
+					"name":      "api-server-6b7c-xyz99",
+					"namespace": "default",
+					"labels":    map[string]any{"app": "api-server"},
+				},
+				"spec":   map[string]any{"containers": []any{map[string]any{"name": "api", "image": "myapp/api:v2.1.0"}}},
+				"status": map[string]any{"phase": "Running"},
+			},
+		},
+		{
+			ID:         0x0011,
+			PreviousID: 0x0010,
+			EventType:  resource.EventModified,
+			Time:       now.Add(-9 * time.Minute),
+			Object: map[string]any{
+				"apiVersion": "v1", "kind": "Pod",
+				"metadata": map[string]any{
+					"name":      "api-server-6b7c-xyz99",
+					"namespace": "default",
+					"labels":    map[string]any{"app": "api-server"},
+				},
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":  "api",
+							"image": "myapp/api:v2.1.0",
+						},
+					},
+				},
+				"status": map[string]any{
+					"phase": "Running",
+					"containerStatuses": []any{
+						map[string]any{
+							"name":         "api",
+							"state":        map[string]any{"waiting": map[string]any{"reason": "CrashLoopBackOff"}},
+							"restartCount": float64(3),
+						},
+					},
+				},
+			},
+			Patch: map[string]any{
+				"status": map[string]any{
+					"containerStatuses": []any{
+						map[string]any{
+							"state":        map[string]any{"waiting": map[string]any{"reason": "CrashLoopBackOff"}},
+							"restartCount": float64(3),
+						},
+					},
+				},
+			},
+		},
+		{
+			ID:         0x0014,
+			PreviousID: 0x0011,
+			EventType:  resource.EventModified,
+			Time:       now.Add(-4 * time.Minute),
+			Object: map[string]any{
+				"apiVersion": "v1", "kind": "Pod",
+				"metadata": map[string]any{
+					"name":      "api-server-6b7c-xyz99",
+					"namespace": "default",
+					"labels":    map[string]any{"app": "api-server"},
+				},
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":  "api",
+							"image": "myapp/api:v2.1.1",
+						},
+					},
+				},
+				"status": map[string]any{
+					"phase": "Running",
+					"containerStatuses": []any{
+						map[string]any{
+							"name":         "api",
+							"state":        map[string]any{"running": map[string]any{}},
+							"restartCount": float64(4),
+						},
+					},
+				},
+			},
+			Patch: map[string]any{
+				"spec":   map[string]any{"containers": []any{map[string]any{"image": "myapp/api:v2.1.1"}}},
+				"status": map[string]any{"containerStatuses": []any{map[string]any{"state": map[string]any{"running": map[string]any{}}}}},
+			},
+		},
+	})
+
+	addResource("uid-deploy-api", "Deployment", "api-server", "default", false, []resource.Revision{
+		{
+			ID: 0x0012, EventType: resource.EventAdded, Time: now.Add(-15 * time.Minute), Object: map[string]any{
+				"apiVersion": "apps/v1", "kind": "Deployment",
+				"metadata": map[string]any{"name": "api-server", "namespace": "default"},
+				"spec": map[string]any{
+					"replicas": float64(2),
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "api",
+									"image": "myapp/api:v2.1.0",
+								},
+							},
+						},
+					},
+				},
+				"status": map[string]any{"readyReplicas": float64(2), "replicas": float64(2)},
+			},
+		},
+	})
+
+	addResource("uid-svc-api", "Service", "api-svc", "default", false, []resource.Revision{
+		{
+			ID: 0x0013, EventType: resource.EventAdded, Time: now.Add(-15 * time.Minute), Object: map[string]any{
+				"apiVersion": "v1", "kind": "Service",
+				"metadata": map[string]any{"name": "api-svc", "namespace": "default"},
+				"spec": map[string]any{
+					"type":     "ClusterIP",
+					"ports":    []any{map[string]any{"port": float64(8080), "targetPort": float64(8080)}},
+					"selector": map[string]any{"app": "api-server"},
+				},
+			},
+		},
+	})
+
+	addResource("uid-pod-coredns", "Pod", "coredns-5644d8b9d-mn123", "kube-system", false, []resource.Revision{
+		{
+			ID: 0x0015, EventType: resource.EventAdded, Time: now.Add(-30 * time.Minute), Object: map[string]any{
+				"apiVersion": "v1", "kind": "Pod",
+				"metadata": map[string]any{
+					"name":      "coredns-5644d8b9d-mn123",
+					"namespace": "kube-system",
+					"labels":    map[string]any{"k8s-app": "kube-dns"},
+				},
+				"spec": map[string]any{
+					"containers": []any{
+						map[string]any{
+							"name":  "coredns",
+							"image": "registry.k8s.io/coredns/coredns:v1.11.1",
+						},
+					},
+				},
+				"status": map[string]any{"phase": "Running", "podIP": "10.0.0.2"},
+			},
+		},
+	})
+
+	addResource("uid-cm-coredns", "ConfigMap", "coredns-config", "kube-system", false, []resource.Revision{
+		{
+			ID: 0x0016, EventType: resource.EventAdded, Time: now.Add(-30 * time.Minute), Object: map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "coredns-config", "namespace": "kube-system"},
+				"data":     map[string]any{"Corefile": ".:53 {\n    errors\n    health\n    kubernetes cluster.local\n    forward . /etc/resolv.conf\n}"},
+			},
+		},
+		{
+			ID:         0x0017,
+			PreviousID: 0x0016,
+			EventType:  resource.EventModified,
+			Time:       now.Add(-8 * time.Minute),
+			Object: map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{"name": "coredns-config", "namespace": "kube-system"},
+				"data":     map[string]any{"Corefile": ".:53 {\n    errors\n    health\n    kubernetes cluster.local\n    forward . 8.8.8.8 8.8.4.4\n}"},
+			},
+			Patch: map[string]any{"data": map[string]any{"Corefile": ".:53 {\n    errors\n    health\n    kubernetes cluster.local\n    forward . 8.8.8.8 8.8.4.4\n}"}},
+		},
+	})
+
+	burstBase := now.Add(-1 * time.Minute)
+
+	addResource("uid-crd-myapp", "MyApp", "production", "operators", true, []resource.Revision{
+		{
+			ID: 0x0020, EventType: resource.EventAdded, Time: burstBase.Add(-10 * time.Minute), Object: map[string]any{
+				"apiVersion": "myapp.example.com/v1", "kind": "MyApp",
+				"metadata": map[string]any{"name": "production", "namespace": "operators"},
+				"spec":     map[string]any{"replicas": float64(2), "image": "myapp/web:v1.0.0", "port": float64(3000)},
+				"status":   map[string]any{"phase": "Pending", "conditions": []any{}},
+			},
+		},
+		{
+			ID:         0x0025,
+			PreviousID: 0x0020,
+			EventType:  resource.EventModified,
+			Time:       burstBase,
+			Object: map[string]any{
+				"apiVersion": "myapp.example.com/v1", "kind": "MyApp",
+				"metadata": map[string]any{"name": "production", "namespace": "operators"},
+				"spec":     map[string]any{"replicas": float64(3), "image": "myapp/web:v1.1.0", "port": float64(3000)},
+				"status":   map[string]any{"phase": "Reconciling"},
+			},
+			Patch: map[string]any{
+				"spec":   map[string]any{"replicas": float64(3), "image": "myapp/web:v1.1.0"},
+				"status": map[string]any{"phase": "Reconciling"},
+			},
+		},
+		{
+			ID:         0x002a,
+			PreviousID: 0x0025,
+			EventType:  resource.EventModified,
+			Time:       burstBase.Add(5 * time.Second),
+			Object: map[string]any{
+				"apiVersion": "myapp.example.com/v1", "kind": "MyApp",
+				"metadata": map[string]any{"name": "production", "namespace": "operators"},
+				"spec":     map[string]any{"replicas": float64(3), "image": "myapp/web:v1.1.0", "port": float64(3000)},
+				"status": map[string]any{
+					"phase":      "Ready",
+					"conditions": []any{map[string]any{"type": "Available", "status": "True"}},
+				},
+			},
+			Patch: map[string]any{"status": map[string]any{"phase": "Ready"}},
+		},
+	})
+
+	addResource("uid-deploy-myapp", "Deployment", "myapp-web", "operators", false, []resource.Revision{
+		{
+			ID: 0x0026, EventType: resource.EventAdded, Time: burstBase.Add(1 * time.Second), Object: map[string]any{
+				"apiVersion": "apps/v1", "kind": "Deployment",
+				"metadata": map[string]any{
+					"name":            "myapp-web",
+					"namespace":       "operators",
+					"ownerReferences": []any{map[string]any{"kind": "MyApp", "name": "production"}},
+				},
+				"spec": map[string]any{
+					"replicas": float64(3),
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "web",
+									"image": "myapp/web:v1.1.0",
+								},
+							},
+						},
+					},
+				},
+				"status": map[string]any{"readyReplicas": float64(0), "replicas": float64(3)},
+			},
+		},
+		{
+			ID:         0x0029,
+			PreviousID: 0x0026,
+			EventType:  resource.EventModified,
+			Time:       burstBase.Add(4 * time.Second),
+			Object: map[string]any{
+				"apiVersion": "apps/v1", "kind": "Deployment",
+				"metadata": map[string]any{
+					"name":            "myapp-web",
+					"namespace":       "operators",
+					"ownerReferences": []any{map[string]any{"kind": "MyApp", "name": "production"}},
+				},
+				"spec": map[string]any{
+					"replicas": float64(3),
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "web",
+									"image": "myapp/web:v1.1.0",
+								},
+							},
+						},
+					},
+				},
+				"status": map[string]any{"readyReplicas": float64(3), "replicas": float64(3)},
+			},
+			Patch: map[string]any{"status": map[string]any{"readyReplicas": float64(3)}},
+		},
+	})
+
+	addResource("uid-svc-myapp", "Service", "myapp-svc", "operators", false, []resource.Revision{
+		{
+			ID: 0x0027, EventType: resource.EventAdded, Time: burstBase.Add(2 * time.Second), Object: map[string]any{
+				"apiVersion": "v1", "kind": "Service",
+				"metadata": map[string]any{
+					"name":            "myapp-svc",
+					"namespace":       "operators",
+					"ownerReferences": []any{map[string]any{"kind": "MyApp", "name": "production"}},
+				},
+				"spec": map[string]any{
+					"type":     "ClusterIP",
+					"ports":    []any{map[string]any{"port": float64(3000), "targetPort": float64(3000)}},
+					"selector": map[string]any{"app": "myapp-web"},
+				},
+			},
+		},
+	})
+
+	addResource("uid-cm-myapp", "ConfigMap", "myapp-config", "operators", false, []resource.Revision{
+		{
+			ID: 0x0028, EventType: resource.EventAdded, Time: burstBase.Add(3 * time.Second), Object: map[string]any{
+				"apiVersion": "v1", "kind": "ConfigMap",
+				"metadata": map[string]any{
+					"name":            "myapp-config",
+					"namespace":       "operators",
+					"ownerReferences": []any{map[string]any{"kind": "MyApp", "name": "production"}},
+				},
+				"data": map[string]any{"DATABASE_URL": "postgres://db:5432/myapp", "LOG_LEVEL": "info"},
+			},
+		},
+	})
+
+	loopObj1 := map[string]any{
+		"apiVersion": "apps/v1", "kind": "Deployment",
+		"metadata": map[string]any{
+			"name": "flaky-operator-deploy", "namespace": "default",
+			"annotations": map[string]any{"operator.example.com/reconcile-hash": "abc123"},
+		},
+		"spec":   map[string]any{"replicas": float64(1)},
+		"status": map[string]any{"readyReplicas": float64(1)},
+	}
+	loopObj2 := map[string]any{
+		"apiVersion": "apps/v1", "kind": "Deployment",
+		"metadata": map[string]any{
+			"name": "flaky-operator-deploy", "namespace": "default",
+			"annotations": map[string]any{"operator.example.com/reconcile-hash": "def456"},
+		},
+		"spec":   map[string]any{"replicas": float64(1)},
+		"status": map[string]any{"readyReplicas": float64(1)},
+	}
+
+	loopRevisions := make([]resource.Revision, 0, 8)
+	loopBase := now.Add(-2 * time.Minute)
+	for i := range 8 {
+		obj := loopObj1
+		if i%2 == 1 {
+			obj = loopObj2
+		}
+		rev := resource.Revision{
+			ID:        resource.RevisionID(0x0030 + i),
+			EventType: resource.EventModified,
+			Time:      loopBase.Add(time.Duration(i*15) * time.Second),
+			Object:    obj,
+			Patch:     map[string]any{"metadata": map[string]any{"annotations": map[string]any{"operator.example.com/reconcile-hash": "changed"}}},
+		}
+		if i == 0 {
+			rev.EventType = resource.EventAdded
+			rev.Patch = nil
+		} else {
+			rev.PreviousID = resource.RevisionID(0x0030 + i - 1)
+		}
+		loopRevisions = append(loopRevisions, rev)
+	}
+	addResource("uid-deploy-flaky", "Deployment", "flaky-operator-deploy", "default", false, loopRevisions)
+
+	var timeline []resource.TimelineEntry
+	for _, rd := range resources {
+		for _, rev := range rd.Revisions {
+			timeline = append(timeline, resource.TimelineEntry{
+				Resource: rd.Resource,
+				Revision: rev,
+			})
+		}
+	}
+	sort.Slice(timeline, func(i, j int) bool {
+		return timeline[i].Revision.Time.After(timeline[j].Revision.Time)
+	})
+
+	allResources := make([]*resource.Data, 0, len(resources))
+	for _, rd := range resources {
+		allResources = append(allResources, rd)
+	}
+	kindGroups := resource.BuildKindGroups(allResources)
+
+	clusterResourceTypes := []resource.Kind{
+		{Kind: "Secret", APIVersion: "v1", Resource: "secrets", Namespaced: true},
+		{Kind: "Ingress", APIVersion: "networking.k8s.io/v1", Resource: "ingresses", Namespaced: true},
+		{Kind: "CronJob", APIVersion: "batch/v1", Resource: "cronjobs", Namespaced: true},
+		{Kind: "HPA", APIVersion: "autoscaling/v2", Resource: "horizontalpodautoscalers", Namespaced: true},
+		{Kind: "PodDisruptionBudget", APIVersion: "policy/v1", Resource: "poddisruptionbudgets", Namespaced: true},
+		{Kind: "Namespace", APIVersion: "v1", Resource: "namespaces", Namespaced: false},
+		{Kind: "ServiceAccount", APIVersion: "v1", Resource: "serviceaccounts", Namespaced: true},
+		{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1", Resource: "clusterroles", Namespaced: false},
+		{Kind: "Endpoints", APIVersion: "v1", Resource: "endpoints", Namespaced: true},
+		{Kind: "PersistentVolume", APIVersion: "v1", Resource: "persistentvolumes", Namespaced: false},
+		{Kind: "PersistentVolumeClaim", APIVersion: "v1", Resource: "persistentvolumeclaims", Namespaced: true},
+		{Kind: "NetworkPolicy", APIVersion: "networking.k8s.io/v1", Resource: "networkpolicies", Namespaced: true},
+		{Kind: "Job", APIVersion: "batch/v1", Resource: "jobs", Namespaced: true},
+		{Kind: "DaemonSet", APIVersion: "apps/v1", Resource: "daemonsets", Namespaced: true},
+		{Kind: "StatefulSet", APIVersion: "apps/v1", Resource: "statefulsets", Namespaced: true},
+		{Kind: "Role", APIVersion: "rbac.authorization.k8s.io/v1", Resource: "roles", Namespaced: true},
+		{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1", Resource: "rolebindings", Namespaced: true},
+		{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Resource:   "clusterrolebindings",
+			Namespaced: false,
+		},
+		{Kind: "LimitRange", APIVersion: "v1", Resource: "limitranges", Namespaced: true},
+		{Kind: "ResourceQuota", APIVersion: "v1", Resource: "resourcequotas", Namespaced: true},
+	}
+
+	return NewStore(resources, timeline, kindGroups, clusterResourceTypes)
+}

--- a/internal/simulation/store.go
+++ b/internal/simulation/store.go
@@ -1,0 +1,701 @@
+package simulation
+
+import (
+	"math/rand"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/loog-project/loog/internal/resource"
+	"github.com/loog-project/loog/internal/tui"
+)
+
+// Store is an in-memory tui.Store implementation for simulation and testing.
+// It also implements tui.Simulator so it can generate live data.
+type Store struct {
+	mu sync.RWMutex
+
+	resources            map[string]*resource.Data
+	timeline             []resource.TimelineEntry
+	kindGroups           []*resource.KindGroup
+	clusterResourceTypes []resource.Kind
+	totalRevisions       int // cached count of all revisions across resources
+}
+
+// Compile-time check that Store implements both interfaces.
+var (
+	_ tui.Store     = (*Store)(nil)
+	_ tui.Simulator = (*Store)(nil)
+)
+
+// NewStore creates a Store from pre-built data.
+func NewStore(
+	resources map[string]*resource.Data,
+	timeline []resource.TimelineEntry,
+	kindGroups []*resource.KindGroup,
+	clusterResourceTypes []resource.Kind,
+) *Store {
+	totalRevs := 0
+	for _, rd := range resources {
+		totalRevs += len(rd.Revisions)
+	}
+	return &Store{
+		resources:            resources,
+		timeline:             timeline,
+		kindGroups:           kindGroups,
+		clusterResourceTypes: clusterResourceTypes,
+		totalRevisions:       totalRevs,
+	}
+}
+
+func (s *Store) AllResources() []*resource.Data {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.allResourcesLocked()
+}
+
+func (s *Store) StarredResources() []*resource.Data {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var result []*resource.Data
+	for _, rd := range s.resources {
+		if rd.Resource.Starred {
+			result = append(result, rd)
+		}
+	}
+	return result
+}
+
+func (s *Store) GetResource(uid string) *resource.Data {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.resources[uid]
+}
+
+func (s *Store) TotalResourceCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return len(s.resources)
+}
+
+func (s *Store) TotalRevisionCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.totalRevisions
+}
+
+func (s *Store) FilterResources(expr string) []*resource.Data {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if expr == "" {
+		return s.allResourcesLocked()
+	}
+	lower := strings.ToLower(expr)
+	var result []*resource.Data
+	for _, rd := range s.resources {
+		if resource.MatchesSubstring(lower, rd.Resource) {
+			result = append(result, rd)
+		}
+	}
+	return result
+}
+
+func (s *Store) FilterTimeline(expr string, starredOnly bool) []resource.TimelineEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if expr == "" && !starredOnly {
+		return s.timeline
+	}
+	lower := strings.ToLower(expr)
+	var result []resource.TimelineEntry
+	for _, e := range s.timeline {
+		if starredOnly && !e.Resource.Starred {
+			continue
+		}
+		if expr != "" && !resource.MatchesSubstring(lower, e.Resource) {
+			continue
+		}
+		result = append(result, e)
+	}
+	return result
+}
+
+func (s *Store) Timeline() []resource.TimelineEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.timeline
+}
+
+func (s *Store) KindGroups() []*resource.KindGroup {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.kindGroups
+}
+
+func (s *Store) WatchedKinds() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.watchedKindsLocked()
+}
+
+func (s *Store) watchedKindsLocked() []string {
+	kindSet := make(map[string]bool)
+	for _, rd := range s.resources {
+		kindSet[rd.Resource.Kind] = true
+	}
+	kinds := make([]string, 0, len(kindSet))
+	for k := range kindSet {
+		kinds = append(kinds, k)
+	}
+	sort.Strings(kinds)
+	return kinds
+}
+
+func (s *Store) ResourceCountByKind(kind string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	count := 0
+	for _, rd := range s.resources {
+		if rd.Resource.Kind == kind {
+			count++
+		}
+	}
+	return count
+}
+
+func (s *Store) RevisionCountByKind(kind string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	count := 0
+	for _, rd := range s.resources {
+		if rd.Resource.Kind == kind {
+			count += len(rd.Revisions)
+		}
+	}
+	return count
+}
+
+func (s *Store) UnwatchedKinds() []resource.Kind {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	watched := s.watchedKindsLocked()
+	watchedSet := make(map[string]bool, len(watched))
+	for _, k := range watched {
+		watchedSet[k] = true
+	}
+	var result []resource.Kind
+	for _, rk := range s.clusterResourceTypes {
+		if !watchedSet[rk.Kind] {
+			result = append(result, rk)
+		}
+	}
+	return result
+}
+
+func (s *Store) AddWatchKind(rk resource.Kind) []*resource.Data {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	var created []*resource.Data
+
+	dummyResources := generateDummyResourcesForKind(rk, now)
+	for _, r := range dummyResources {
+		initRev := resource.Revision{
+			ID:        resource.RevisionID(uint64(now.UnixNano()&0xFFFF) + uint64(len(s.resources))),
+			EventType: resource.EventAdded,
+			Time:      now.Add(-time.Duration(len(created)) * 500 * time.Millisecond),
+			Object: map[string]any{
+				"apiVersion": rk.APIVersion,
+				"kind":       rk.Kind,
+				"metadata":   r.meta,
+				"spec":       r.spec,
+				"status":     r.status,
+			},
+		}
+
+		rd := &resource.Data{
+			Resource: resource.Resource{
+				UID:       r.uid,
+				Kind:      rk.Kind,
+				Name:      r.name,
+				Namespace: r.namespace,
+			},
+			Revisions: []resource.Revision{initRev},
+		}
+		s.resources[r.uid] = rd
+		s.totalRevisions++
+		created = append(created, rd)
+
+		s.timeline = append(s.timeline, resource.TimelineEntry{
+			Resource: rd.Resource,
+			Revision: initRev,
+		})
+	}
+
+	sort.Slice(s.timeline, func(i, j int) bool {
+		return s.timeline[i].Revision.Time.After(s.timeline[j].Revision.Time)
+	})
+	return created
+}
+
+func (s *Store) RemoveWatchKind(kind string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var toRemove []string
+	for uid, rd := range s.resources {
+		if rd.Resource.Kind == kind {
+			s.totalRevisions -= len(rd.Revisions)
+			toRemove = append(toRemove, uid)
+		}
+	}
+	for _, uid := range toRemove {
+		delete(s.resources, uid)
+	}
+
+	removeSet := make(map[string]bool, len(toRemove))
+	for _, uid := range toRemove {
+		removeSet[uid] = true
+	}
+	filtered := make([]resource.TimelineEntry, 0, len(s.timeline)-len(toRemove))
+	for _, e := range s.timeline {
+		if !removeSet[e.Resource.UID] {
+			filtered = append(filtered, e)
+		}
+	}
+	s.timeline = filtered
+}
+
+func (s *Store) ToggleStar(uid string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rd, ok := s.resources[uid]
+	if !ok {
+		return false
+	}
+	rd.Resource.Starred = !rd.Resource.Starred
+	for i := range s.timeline {
+		if s.timeline[i].Resource.UID == uid {
+			s.timeline[i].Resource.Starred = rd.Resource.Starred
+		}
+	}
+	return rd.Resource.Starred
+}
+
+func (s *Store) AddRevision(resourceUID string, rev resource.Revision) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	rd, ok := s.resources[resourceUID]
+	if !ok {
+		return
+	}
+	rd.Revisions = append(rd.Revisions, rev)
+	s.totalRevisions++
+
+	// Timeline is sorted newest-first. New simulation revisions are always
+	// the most recent, so prepending maintains sort order without re-sorting.
+	s.timeline = append(s.timeline, resource.TimelineEntry{})
+	copy(s.timeline[1:], s.timeline)
+	s.timeline[0] = resource.TimelineEntry{
+		Resource: rd.Resource,
+		Revision: rev,
+	}
+}
+
+func (s *Store) RebuildKindGroups() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.kindGroups = resource.BuildKindGroups(s.allResourcesLocked())
+}
+
+func (s *Store) ForEachResource(fn func(uid string, rd *resource.Data)) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for uid, rd := range s.resources {
+		fn(uid, rd)
+	}
+}
+
+// allResourcesLocked returns all resources sorted by kind/name.
+// Must be called with at least s.mu.RLock held.
+func (s *Store) allResourcesLocked() []*resource.Data {
+	result := make([]*resource.Data, 0, len(s.resources))
+	for _, rd := range s.resources {
+		result = append(result, rd)
+	}
+	resource.SortByKindName(result)
+	return result
+}
+
+// ScheduleNextTick returns a tea.Cmd that generates a SimulationTickMsg
+// for a random resource after a 3-5 second delay.
+func (s *Store) ScheduleNextTick() tea.Cmd {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if len(s.resources) == 0 {
+		return nil
+	}
+	uids := make([]string, 0, len(s.resources))
+	for uid := range s.resources {
+		uids = append(uids, uid)
+	}
+	return func() tea.Msg {
+		delay := time.Duration(3+rand.Intn(3)) * time.Second
+		time.Sleep(delay)
+		uid := uids[rand.Intn(len(uids))]
+		return tui.SimulationTickMsg{ResourceUID: uid}
+	}
+}
+
+// GenerateRevision creates a new MODIFIED revision for the given resource.
+func (s *Store) GenerateRevision(rd *resource.Data) resource.Revision {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	latest := rd.LatestRevision()
+
+	var newObj map[string]any
+	if latest != nil && latest.Object != nil {
+		newObj = resource.CloneMap(latest.Object)
+	} else {
+		newObj = map[string]any{
+			"apiVersion": "v1",
+			"kind":       rd.Resource.Kind,
+			"metadata":   map[string]any{"name": rd.Resource.Name},
+		}
+	}
+
+	meta, _ := newObj["metadata"].(map[string]any)
+	if meta == nil {
+		meta = map[string]any{}
+		newObj["metadata"] = meta
+	}
+	annotations, _ := meta["annotations"].(map[string]any)
+	if annotations == nil {
+		annotations = map[string]any{}
+		meta["annotations"] = annotations
+	}
+	annotations["loog.dev/last-seen"] = now.Format(time.RFC3339)
+
+	var newID resource.RevisionID
+	var prevID resource.RevisionID
+	if latest != nil {
+		prevID = latest.ID
+		newID = resource.RevisionID(uint64(latest.ID) + 1)
+	} else {
+		newID = resource.RevisionID(0xF000 + uint64(rand.Intn(0xFFF)))
+	}
+
+	return resource.Revision{
+		ID:         newID,
+		PreviousID: prevID,
+		EventType:  resource.EventModified,
+		Time:       now,
+		Object:     newObj,
+		Patch: map[string]any{
+			"metadata": map[string]any{
+				"annotations": map[string]any{
+					"loog.dev/last-seen": now.Format(time.RFC3339),
+				},
+			},
+		},
+	}
+}
+
+type dummyResourceSpec struct {
+	uid       string
+	name      string
+	namespace string
+	meta      map[string]any
+	spec      map[string]any
+	status    map[string]any
+}
+
+func generateDummyResourcesForKind(rk resource.Kind, now time.Time) []dummyResourceSpec {
+	ns := "default"
+	if !rk.Namespaced {
+		ns = ""
+	}
+	uid := func(suffix string) string {
+		return "watched-" + strings.ToLower(rk.Kind) + "-" + suffix
+	}
+	meta := func(name, namespace string) map[string]any {
+		m := map[string]any{
+			"name":              name,
+			"creationTimestamp": now.Add(-1 * time.Hour).Format(time.RFC3339),
+		}
+		if namespace != "" {
+			m["namespace"] = namespace
+		}
+		return m
+	}
+
+	switch rk.Kind {
+	case "Secret":
+		return []dummyResourceSpec{
+			{
+				uid: uid("tls-cert"), name: "tls-cert", namespace: ns,
+				meta: meta("tls-cert", ns), spec: map[string]any{"type": "kubernetes.io/tls"},
+				status: map[string]any{},
+			},
+			{
+				uid: uid("db-creds"), name: "db-credentials", namespace: ns,
+				meta: meta("db-credentials", ns), spec: map[string]any{"type": "Opaque"},
+				status: map[string]any{},
+			},
+		}
+	case "Ingress":
+		return []dummyResourceSpec{
+			{
+				uid: uid("api-gw"), name: "api-gateway", namespace: ns,
+				meta: meta("api-gateway", ns),
+				spec: map[string]any{
+					"rules": []any{
+						map[string]any{
+							"host": "api.example.com",
+							"http": map[string]any{
+								"paths": []any{
+									map[string]any{
+										"path": "/",
+										"backend": map[string]any{
+											"service": map[string]any{
+												"name": "api-svc",
+												"port": float64(8080),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				status: map[string]any{"loadBalancer": map[string]any{}},
+			},
+			{
+				uid: uid("web-fe"), name: "web-frontend", namespace: ns,
+				meta:   meta("web-frontend", ns),
+				spec:   map[string]any{"rules": []any{map[string]any{"host": "www.example.com"}}},
+				status: map[string]any{"loadBalancer": map[string]any{}},
+			},
+		}
+	case "CronJob":
+		return []dummyResourceSpec{
+			{
+				uid: uid("db-backup"), name: "db-backup", namespace: ns,
+				meta: meta("db-backup", ns),
+				spec: map[string]any{
+					"schedule": "0 2 * * *",
+					"jobTemplate": map[string]any{
+						"spec": map[string]any{
+							"template": map[string]any{
+								"spec": map[string]any{
+									"containers": []any{
+										map[string]any{
+											"name":  "backup",
+											"image": "postgres:16",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				status: map[string]any{"lastScheduleTime": now.Add(-2 * time.Hour).Format(time.RFC3339)},
+			},
+			{
+				uid: uid("log-cleanup"), name: "log-cleanup", namespace: "kube-system",
+				meta: meta("log-cleanup", "kube-system"),
+				spec: map[string]any{
+					"schedule": "0 */6 * * *",
+					"jobTemplate": map[string]any{
+						"spec": map[string]any{
+							"template": map[string]any{
+								"spec": map[string]any{
+									"containers": []any{
+										map[string]any{
+											"name":  "cleaner",
+											"image": "busybox:latest",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				status: map[string]any{},
+			},
+		}
+	case "HPA":
+		return []dummyResourceSpec{
+			{
+				uid: uid("nginx-as"), name: "nginx-autoscaler", namespace: ns,
+				meta: meta("nginx-autoscaler", ns),
+				spec: map[string]any{
+					"scaleTargetRef":                 map[string]any{"kind": "Deployment", "name": "nginx-deployment"},
+					"minReplicas":                    float64(1),
+					"maxReplicas":                    float64(10),
+					"targetCPUUtilizationPercentage": float64(50),
+				},
+				status: map[string]any{"currentReplicas": float64(3), "desiredReplicas": float64(3)},
+			},
+		}
+	case "PodDisruptionBudget":
+		return []dummyResourceSpec{
+			{
+				uid: uid("nginx-pdb"), name: "nginx-pdb", namespace: ns,
+				meta: meta("nginx-pdb", ns),
+				spec: map[string]any{
+					"minAvailable": float64(1),
+					"selector":     map[string]any{"matchLabels": map[string]any{"app": "nginx"}},
+				},
+				status: map[string]any{"currentHealthy": float64(3), "desiredHealthy": float64(1)},
+			},
+		}
+	case "Namespace":
+		return []dummyResourceSpec{
+			{
+				uid: uid("monitoring"), name: "monitoring", namespace: "",
+				meta: meta("monitoring", ""), spec: map[string]any{},
+				status: map[string]any{"phase": "Active"},
+			},
+			{
+				uid: uid("staging"), name: "staging", namespace: "",
+				meta: meta("staging", ""), spec: map[string]any{},
+				status: map[string]any{"phase": "Active"},
+			},
+		}
+	case "ServiceAccount":
+		return []dummyResourceSpec{
+			{
+				uid: uid("deploy-bot"), name: "deploy-bot", namespace: ns,
+				meta:   meta("deploy-bot", ns),
+				spec:   map[string]any{"automountServiceAccountToken": true},
+				status: map[string]any{},
+			},
+		}
+	case "ClusterRole":
+		return []dummyResourceSpec{
+			{
+				uid: uid("custom-admin"), name: "custom-admin", namespace: "",
+				meta: meta("custom-admin", ""),
+				spec: map[string]any{
+					"rules": []any{
+						map[string]any{
+							"apiGroups": []any{"*"},
+							"resources": []any{"*"},
+							"verbs":     []any{"*"},
+						},
+					},
+				},
+				status: map[string]any{},
+			},
+		}
+	case "Endpoints":
+		return []dummyResourceSpec{
+			{
+				uid: uid("nginx-ep"), name: "nginx-svc", namespace: ns,
+				meta: meta("nginx-svc", ns),
+				spec: map[string]any{
+					"subsets": []any{
+						map[string]any{
+							"addresses": []any{
+								map[string]any{"ip": "10.0.1.15"},
+								map[string]any{"ip": "10.0.1.16"},
+							}, "ports": []any{map[string]any{"port": float64(80)}},
+						},
+					},
+				},
+				status: map[string]any{},
+			},
+		}
+	case "PersistentVolume":
+		return []dummyResourceSpec{
+			{
+				uid: uid("data-pv"), name: "data-pv-01", namespace: "",
+				meta: meta("data-pv-01", ""),
+				spec: map[string]any{
+					"capacity":         map[string]any{"storage": "100Gi"},
+					"accessModes":      []any{"ReadWriteOnce"},
+					"storageClassName": "standard",
+				},
+				status: map[string]any{"phase": "Bound"},
+			},
+		}
+	case "PersistentVolumeClaim":
+		return []dummyResourceSpec{
+			{
+				uid: uid("data-pvc"), name: "data-pvc", namespace: ns,
+				meta: meta("data-pvc", ns),
+				spec: map[string]any{
+					"accessModes": []any{"ReadWriteOnce"},
+					"resources":   map[string]any{"requests": map[string]any{"storage": "50Gi"}},
+				},
+				status: map[string]any{"phase": "Bound", "capacity": map[string]any{"storage": "50Gi"}},
+			},
+		}
+	case "NetworkPolicy":
+		return []dummyResourceSpec{
+			{
+				uid: uid("default-deny"), name: "default-deny", namespace: ns,
+				meta:   meta("default-deny", ns),
+				spec:   map[string]any{"podSelector": map[string]any{}, "policyTypes": []any{"Ingress", "Egress"}},
+				status: map[string]any{},
+			},
+		}
+	case "Job":
+		return []dummyResourceSpec{
+			{
+				uid: uid("db-migrate"), name: "db-migrate-v2", namespace: ns,
+				meta: meta("db-migrate-v2", ns),
+				spec: map[string]any{
+					"template": map[string]any{
+						"spec": map[string]any{
+							"containers": []any{
+								map[string]any{
+									"name":  "migrate",
+									"image": "myapp/migrate:v2",
+								},
+							}, "restartPolicy": "Never",
+						},
+					},
+				},
+				status: map[string]any{
+					"succeeded":      float64(1),
+					"completionTime": now.Add(-30 * time.Minute).Format(time.RFC3339),
+				},
+			},
+		}
+	default:
+		return []dummyResourceSpec{
+			{
+				uid: uid("instance-1"), name: rk.Kind + "-instance-1", namespace: ns,
+				meta:   meta(rk.Kind+"-instance-1", ns),
+				spec:   map[string]any{"placeholder": "(auto-generated)"},
+				status: map[string]any{"phase": "Active"},
+			},
+		}
+	}
+}


### PR DESCRIPTION
## Summary

### New `internal/simulation/` package (2 files, ~1,474 lines)
- Generates realistic Kubernetes resource histories: Pods with CrashLoopBackOff cycles, Deployments with rolling updates, Services, ConfigMaps with configuration drift, ReplicaSets with scaling events, HPAs, PVCs, and Namespaces
- Each resource gets a multi-revision history with realistic state transitions
- In-memory `Store` implementing both `tui.Store` and `tui.Simulator` interfaces
- `NextSimRevision()` tea.Cmd for generating live data at random intervals during simulation mode
- Thread-safe with `sync.RWMutex`

### CLI integration
- `--simulate` flag to run TUI with generated data, no cluster needed
- Kubernetes connection and arg validation skipped in simulate mode
- klog and stderr output suppressed in simulate mode

## Why
Simulation mode lets you develop and demo the TUI without a live Kubernetes cluster. It plugs cleanly into the `tui.Store` interface that was established in PR 6.

## Stack
This is **PR 7 of 7** in the v2 series.
`v2` ← 01-dependency-upgrades ← 02-store-improvements ← 03-pkg-mux ← 04-diffmap-diffpreview ← 05-domain-types ← 06-new-tui ← **07-simulation**