### PR TITLE
fix: concurrency safety and simulation correctness in v2 TUI

### DIFF
--- a/internal/adapter/livestore.go
+++ b/internal/adapter/livestore.go
@@ -176,8 +176,11 @@ func (s *LiveStore) KindGroups() []*resource.KindGroup {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// Return cached kind groups
-	return s.kindGroups
+	// Return a shallow copy of the slice so a concurrent RebuildKindGroups
+	// (which reassigns s.kindGroups) cannot race with the caller iterating it.
+	out := make([]*resource.KindGroup, len(s.kindGroups))
+	copy(out, s.kindGroups)
+	return out
 }
 
 func (s *LiveStore) WatchedKinds() []string {
@@ -222,9 +225,11 @@ func (s *LiveStore) UnwatchedKinds() []resource.Kind {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// In production mode, unwatched kinds could be populated from API discovery.
-	// For now, return whatever was set externally.
-	return s.unwatchedKinds
+	// Return a copy: callers (e.g. the watch manager) retain this slice across
+	// render frames, and AddWatchKind must not mutate the array underneath them.
+	out := make([]resource.Kind, len(s.unwatchedKinds))
+	copy(out, s.unwatchedKinds)
+	return out
 }
 
 func (s *LiveStore) AddWatchKind(rk resource.Kind) []*resource.Data {
@@ -233,8 +238,9 @@ func (s *LiveStore) AddWatchKind(rk resource.Kind) []*resource.Data {
 
 	s.watchedKinds[rk.Kind] = true
 
-	// Remove from unwatched list
-	filtered := s.unwatchedKinds[:0]
+	// Remove from unwatched list. Allocate a fresh slice instead of reusing the
+	// backing array with [:0]; the old array may still be held by the UI.
+	filtered := make([]resource.Kind, 0, len(s.unwatchedKinds))
 	for _, uk := range s.unwatchedKinds {
 		if uk.Kind != rk.Kind {
 			filtered = append(filtered, uk)
@@ -326,19 +332,35 @@ func (s *LiveStore) RebuildKindGroups() {
 }
 
 func (s *LiveStore) ForEachResource(fn func(uid string, rd *resource.Data)) {
+	// Snapshot under the lock, then invoke the callback outside it. This keeps
+	// the write lock off the collector's ingestion path while the callback does
+	// potentially slow work (e.g. rendering), and avoids RWMutex re-entry
+	// deadlocks if fn calls back into the store.
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-
+	type entry struct {
+		uid string
+		rd  *resource.Data
+	}
+	snapshot := make([]entry, 0, len(s.resources))
 	for uid, rd := range s.resources {
-		fn(uid, rd)
+		snapshot = append(snapshot, entry{uid, rd})
+	}
+	s.mu.RUnlock()
+
+	for _, e := range snapshot {
+		fn(e.uid, e.rd)
 	}
 }
 
 // SetUnwatchedKinds sets the list of unwatched resource kinds available on the cluster.
 func (s *LiveStore) SetUnwatchedKinds(kinds []resource.Kind) {
+	// Copy so the store owns its backing array independent of the caller.
+	owned := make([]resource.Kind, len(kinds))
+	copy(owned, kinds)
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.unwatchedKinds = kinds
+	s.unwatchedKinds = owned
 }
 
 func (s *LiveStore) allResourcesLocked() []*resource.Data {

--- a/internal/adapter/livestore_test.go
+++ b/internal/adapter/livestore_test.go
@@ -1,0 +1,115 @@
+package adapter
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/loog-project/loog/internal/resource"
+)
+
+// TestUnwatchedKinds_ReturnedSliceNotCorruptedByAddWatchKind verifies that a
+// slice returned from UnwatchedKinds() is not mutated by a later AddWatchKind
+// call. Previously AddWatchKind reused the backing array via [:0], corrupting
+// any slice the watch manager still held.
+func TestUnwatchedKinds_ReturnedSliceNotCorruptedByAddWatchKind(t *testing.T) {
+	s := NewLiveStore()
+	s.SetUnwatchedKinds([]resource.Kind{
+		{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true},
+		{Kind: "Service", APIVersion: "v1", Resource: "services", Namespaced: true},
+		{Kind: "ConfigMap", APIVersion: "v1", Resource: "configmaps", Namespaced: true},
+	})
+
+	held := s.UnwatchedKinds()
+	if len(held) != 3 {
+		t.Fatalf("expected 3 unwatched kinds, got %d", len(held))
+	}
+	before := make([]string, len(held))
+	for i, k := range held {
+		before[i] = k.Kind
+	}
+
+	// Start watching one kind; this must not mutate the slice we already hold.
+	s.AddWatchKind(resource.Kind{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true})
+
+	for i, k := range held {
+		if k.Kind != before[i] {
+			t.Errorf("held slice mutated at %d: got %q, want %q", i, k.Kind, before[i])
+		}
+	}
+
+	// And the fresh view should have Pod removed.
+	after := s.UnwatchedKinds()
+	if len(after) != 2 {
+		t.Fatalf("expected 2 unwatched kinds after AddWatchKind, got %d", len(after))
+	}
+	for _, k := range after {
+		if k.Kind == "Pod" {
+			t.Errorf("Pod should have been removed from unwatched kinds")
+		}
+	}
+}
+
+// TestSetUnwatchedKinds_CopiesInput verifies the store does not alias the
+// caller's slice.
+func TestSetUnwatchedKinds_CopiesInput(t *testing.T) {
+	s := NewLiveStore()
+	input := []resource.Kind{
+		{Kind: "Pod", APIVersion: "v1", Resource: "pods", Namespaced: true},
+	}
+	s.SetUnwatchedKinds(input)
+
+	// Mutate the caller's slice; the store must be unaffected.
+	input[0] = resource.Kind{Kind: "Hacked"}
+
+	got := s.UnwatchedKinds()
+	if len(got) != 1 || got[0].Kind != "Pod" {
+		t.Errorf("store aliased caller slice: got %+v", got)
+	}
+}
+
+// TestKindGroups_ReturnsCopy verifies mutating the returned slice header does
+// not affect the store's internal slice.
+func TestKindGroups_ReturnsCopy(t *testing.T) {
+	s := NewLiveStore()
+	s.IngestRevision("uid-1", "Pod", "nginx", "default", resource.Revision{ID: 1})
+	s.RebuildKindGroups()
+
+	groups := s.KindGroups()
+	if len(groups) == 0 {
+		t.Fatal("expected at least one kind group")
+	}
+	// Truncating the returned slice must not affect the store.
+	_ = groups[:0]
+	if len(s.KindGroups()) == 0 {
+		t.Error("store's kind groups were affected by caller truncation")
+	}
+}
+
+// TestConcurrentIngestAndRead runs ingestion and reads concurrently to catch
+// races under `go test -race`.
+func TestConcurrentIngestAndRead(t *testing.T) {
+	s := NewLiveStore()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			s.IngestRevision("uid-1", "Pod", "nginx", "default", resource.Revision{ID: resource.RevisionID(i)})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			_ = s.AllResources()
+			_ = s.Timeline()
+			_ = s.KindGroups()
+			s.RebuildKindGroups()
+			s.ForEachResource(func(string, *resource.Data) {})
+		}
+	}()
+
+	wg.Wait()
+}

--- a/internal/simulation/simulation.go
+++ b/internal/simulation/simulation.go
@@ -709,8 +709,9 @@ func New() *Store {
 			ID:        resource.RevisionID(0x0030 + i),
 			EventType: resource.EventModified,
 			Time:      loopBase.Add(time.Duration(i*15) * time.Second),
-			Object:    obj,
-			Patch:     map[string]any{"metadata": map[string]any{"annotations": map[string]any{"operator.example.com/reconcile-hash": "changed"}}},
+			// Clone per revision so sibling revisions don't alias the same map.
+			Object: resource.CloneMap(obj),
+			Patch:  map[string]any{"metadata": map[string]any{"annotations": map[string]any{"operator.example.com/reconcile-hash": "changed"}}},
 		}
 		if i == 0 {
 			rev.EventType = resource.EventAdded

--- a/internal/simulation/store.go
+++ b/internal/simulation/store.go
@@ -22,7 +22,8 @@ type Store struct {
 	timeline             []resource.TimelineEntry
 	kindGroups           []*resource.KindGroup
 	clusterResourceTypes []resource.Kind
-	totalRevisions       int // cached count of all revisions across resources
+	totalRevisions       int    // cached count of all revisions across resources
+	nextID               uint64 // monotonic source of unique revision IDs
 }
 
 // Compile-time check that Store implements both interfaces.
@@ -38,9 +39,18 @@ func NewStore(
 	kindGroups []*resource.KindGroup,
 	clusterResourceTypes []resource.Kind,
 ) *Store {
+	if resources == nil {
+		resources = make(map[string]*resource.Data)
+	}
 	totalRevs := 0
+	var maxID uint64
 	for _, rd := range resources {
 		totalRevs += len(rd.Revisions)
+		for _, rev := range rd.Revisions {
+			if uint64(rev.ID) > maxID {
+				maxID = uint64(rev.ID)
+			}
+		}
 	}
 	return &Store{
 		resources:            resources,
@@ -48,7 +58,19 @@ func NewStore(
 		kindGroups:           kindGroups,
 		clusterResourceTypes: clusterResourceTypes,
 		totalRevisions:       totalRevs,
+		nextID:               maxID + 1,
 	}
+}
+
+// nextRevisionIDLocked returns a unique, monotonically increasing revision ID.
+// The caller must hold s.mu.
+func (s *Store) nextRevisionIDLocked() resource.RevisionID {
+	if s.nextID == 0 {
+		s.nextID = 1
+	}
+	id := s.nextID
+	s.nextID++
+	return resource.RevisionID(id)
 }
 
 func (s *Store) AllResources() []*resource.Data {
@@ -114,7 +136,9 @@ func (s *Store) FilterTimeline(expr string, starredOnly bool) []resource.Timelin
 	defer s.mu.RUnlock()
 
 	if expr == "" && !starredOnly {
-		return s.timeline
+		result := make([]resource.TimelineEntry, len(s.timeline))
+		copy(result, s.timeline)
+		return result
 	}
 	lower := strings.ToLower(expr)
 	var result []resource.TimelineEntry
@@ -134,14 +158,18 @@ func (s *Store) Timeline() []resource.TimelineEntry {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.timeline
+	result := make([]resource.TimelineEntry, len(s.timeline))
+	copy(result, s.timeline)
+	return result
 }
 
 func (s *Store) KindGroups() []*resource.KindGroup {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return s.kindGroups
+	out := make([]*resource.KindGroup, len(s.kindGroups))
+	copy(out, s.kindGroups)
+	return out
 }
 
 func (s *Store) WatchedKinds() []string {
@@ -218,7 +246,7 @@ func (s *Store) AddWatchKind(rk resource.Kind) []*resource.Data {
 	dummyResources := generateDummyResourcesForKind(rk, now)
 	for _, r := range dummyResources {
 		initRev := resource.Revision{
-			ID:        resource.RevisionID(uint64(now.UnixNano()&0xFFFF) + uint64(len(s.resources))),
+			ID:        s.nextRevisionIDLocked(),
 			EventType: resource.EventAdded,
 			Time:      now.Add(-time.Duration(len(created)) * 500 * time.Millisecond),
 			Object: map[string]any{
@@ -329,11 +357,22 @@ func (s *Store) RebuildKindGroups() {
 }
 
 func (s *Store) ForEachResource(fn func(uid string, rd *resource.Data)) {
+	// Snapshot under the lock, then invoke the callback outside it to avoid
+	// holding the lock across arbitrary caller work and to prevent RWMutex
+	// re-entry deadlocks if fn calls back into the store.
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-
+	type entry struct {
+		uid string
+		rd  *resource.Data
+	}
+	snapshot := make([]entry, 0, len(s.resources))
 	for uid, rd := range s.resources {
-		fn(uid, rd)
+		snapshot = append(snapshot, entry{uid, rd})
+	}
+	s.mu.RUnlock()
+
+	for _, e := range snapshot {
+		fn(e.uid, e.rd)
 	}
 }
 
@@ -349,8 +388,9 @@ func (s *Store) allResourcesLocked() []*resource.Data {
 }
 
 // ScheduleNextTick returns a tea.Cmd that generates a SimulationTickMsg
-// for a random resource after a 3-5 second delay.
-func (s *Store) ScheduleNextTick() tea.Cmd {
+// for a random resource after a 3-5 second delay. The epoch is echoed back
+// in the message so the App can discard ticks from a superseded chain.
+func (s *Store) ScheduleNextTick(epoch uint64) tea.Cmd {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -365,11 +405,12 @@ func (s *Store) ScheduleNextTick() tea.Cmd {
 		delay := time.Duration(3+rand.Intn(3)) * time.Second
 		time.Sleep(delay)
 		uid := uids[rand.Intn(len(uids))]
-		return tui.SimulationTickMsg{ResourceUID: uid}
+		return tui.SimulationTickMsg{ResourceUID: uid, Epoch: epoch}
 	}
 }
 
-// GenerateRevision creates a new MODIFIED revision for the given resource.
+// GenerateRevision creates a new revision for the given resource. It is tagged
+// ADDED for a resource's first revision and MODIFIED thereafter.
 func (s *Store) GenerateRevision(rd *resource.Data) resource.Revision {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -400,19 +441,20 @@ func (s *Store) GenerateRevision(rd *resource.Data) resource.Revision {
 	}
 	annotations["loog.dev/last-seen"] = now.Format(time.RFC3339)
 
-	var newID resource.RevisionID
 	var prevID resource.RevisionID
+	eventType := resource.EventModified
 	if latest != nil {
 		prevID = latest.ID
-		newID = resource.RevisionID(uint64(latest.ID) + 1)
 	} else {
-		newID = resource.RevisionID(0xF000 + uint64(rand.Intn(0xFFF)))
+		// No prior revision: this is the first time we see the resource.
+		eventType = resource.EventAdded
 	}
+	newID := s.nextRevisionIDLocked()
 
 	return resource.Revision{
 		ID:         newID,
 		PreviousID: prevID,
-		EventType:  resource.EventModified,
+		EventType:  eventType,
 		Time:       now,
 		Object:     newObj,
 		Patch: map[string]any{

--- a/internal/simulation/store_test.go
+++ b/internal/simulation/store_test.go
@@ -1,0 +1,101 @@
+package simulation
+
+import (
+	"testing"
+
+	"github.com/loog-project/loog/internal/resource"
+)
+
+// TestGeneratedRevisionIDsAreUnique verifies that IDs produced by the store's
+// generators do not collide, including against the pre-built demo data.
+// Previously IDs were derived from nanosecond-masking and rand, which could
+// collide and make the TUI conflate distinct revisions.
+func TestGeneratedRevisionIDsAreUnique(t *testing.T) {
+	s := New()
+
+	seen := make(map[resource.RevisionID]bool)
+	// Collect all pre-built IDs.
+	s.ForEachResource(func(_ string, rd *resource.Data) {
+		for _, rev := range rd.Revisions {
+			if seen[rev.ID] {
+				t.Fatalf("duplicate pre-built revision ID: %d", rev.ID)
+			}
+			seen[rev.ID] = true
+		}
+	})
+
+	// Generate many new revisions and ensure none collide.
+	all := s.AllResources()
+	if len(all) == 0 {
+		t.Fatal("expected pre-built resources")
+	}
+	for i := 0; i < 1000; i++ {
+		rd := all[i%len(all)]
+		rev := s.GenerateRevision(rd)
+		if seen[rev.ID] {
+			t.Fatalf("duplicate generated revision ID: %d (iteration %d)", rev.ID, i)
+		}
+		seen[rev.ID] = true
+		s.AddRevision(rd.Resource.UID, rev)
+		// Refresh rd so LatestRevision reflects the appended revision.
+		rd = s.GetResource(rd.Resource.UID)
+		all[i%len(all)] = rd
+	}
+}
+
+// TestAddWatchKindIDsUnique verifies AddWatchKind assigns unique IDs that do
+// not collide with existing data.
+func TestAddWatchKindIDsUnique(t *testing.T) {
+	s := New()
+
+	seen := make(map[resource.RevisionID]bool)
+	s.ForEachResource(func(_ string, rd *resource.Data) {
+		for _, rev := range rd.Revisions {
+			seen[rev.ID] = true
+		}
+	})
+
+	created := s.AddWatchKind(resource.Kind{
+		Kind: "Secret", APIVersion: "v1", Resource: "secrets", Namespaced: true,
+	})
+	if len(created) == 0 {
+		t.Fatal("expected AddWatchKind to create resources")
+	}
+	for _, rd := range created {
+		for _, rev := range rd.Revisions {
+			if seen[rev.ID] {
+				t.Errorf("AddWatchKind produced colliding revision ID: %d", rev.ID)
+			}
+			seen[rev.ID] = true
+		}
+	}
+}
+
+// TestGenerateRevisionFirstIsAdded verifies a resource's first generated
+// revision is tagged ADDED, and subsequent ones MODIFIED with a correct chain.
+func TestGenerateRevisionFirstIsAdded(t *testing.T) {
+	s := NewStore(nil, nil, nil, nil)
+	rd := &resource.Data{
+		Resource: resource.Resource{UID: "u1", Kind: "Pod", Name: "p", Namespace: "default"},
+	}
+
+	first := s.GenerateRevision(rd)
+	if first.EventType != resource.EventAdded {
+		t.Errorf("first revision event = %v, want ADDED", first.EventType)
+	}
+	if first.PreviousID != 0 {
+		t.Errorf("first revision PreviousID = %d, want 0", first.PreviousID)
+	}
+	rd.Revisions = append(rd.Revisions, first)
+
+	second := s.GenerateRevision(rd)
+	if second.EventType != resource.EventModified {
+		t.Errorf("second revision event = %v, want MODIFIED", second.EventType)
+	}
+	if second.PreviousID != first.ID {
+		t.Errorf("second revision PreviousID = %d, want %d", second.PreviousID, first.ID)
+	}
+	if second.ID == first.ID {
+		t.Errorf("second revision ID must differ from first (%d)", first.ID)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -59,6 +59,10 @@ type App struct {
 	// Simulation
 	simulator  Simulator // nil when running against a production store
 	simulating bool
+	// simEpoch identifies the current tick chain. It is incremented whenever
+	// simulation is paused or resumed so that in-flight ticks from a superseded
+	// chain are discarded instead of spawning overlapping generators.
+	simEpoch uint64
 
 	// Recording: live data arriving from production watcher.
 	// When true, the TUI is in "recording" mode (not simulation).
@@ -184,7 +188,7 @@ func (a *App) Init() tea.Cmd {
 	}
 	// Start simulation if enabled
 	if a.simulating && a.simulator != nil {
-		cmds = append(cmds, a.simulator.ScheduleNextTick())
+		cmds = append(cmds, a.simulator.ScheduleNextTick(a.simEpoch))
 	}
 	return tea.Batch(cmds...)
 }
@@ -574,13 +578,16 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case TogglePauseMsg:
 		a.simulating = !a.simulating
+		// Bump the epoch so any tick still sleeping under the previous epoch is
+		// discarded when it fires, preventing overlapping tick chains.
+		a.simEpoch++
 		a.header.SetRecording(a.simulating)
 		a.statusBar.SetSimulating(a.simulating)
 		if a.simulating {
 			a.setStatus("Recording resumed", false)
 			// Schedule a new simulation tick to restart generation (simulation mode only)
 			if a.simulator != nil {
-				cmds = append(cmds, a.simulator.ScheduleNextTick())
+				cmds = append(cmds, a.simulator.ScheduleNextTick(a.simEpoch))
 			}
 		} else {
 			a.setStatus("Recording paused", false)
@@ -601,10 +608,15 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		a.syncAnalysisTags()
 
 	case SimulationTickMsg:
+		// Drop ticks from a superseded chain (e.g. scheduled before a
+		// pause/resume). Only the current epoch may generate and reschedule.
+		if msg.Epoch != a.simEpoch {
+			break
+		}
 		a.handleSimulationTick(msg.ResourceUID)
 		// Schedule next tick
 		if a.simulating && a.simulator != nil {
-			cmds = append(cmds, a.simulator.ScheduleNextTick())
+			cmds = append(cmds, a.simulator.ScheduleNextTick(a.simEpoch))
 		}
 
 	case adapter.LiveRevisionMsg:

--- a/internal/tui/messages.go
+++ b/internal/tui/messages.go
@@ -75,6 +75,10 @@ type AnalysisCompleteMsg struct {
 
 type SimulationTickMsg struct {
 	ResourceUID string
+	// Epoch identifies the tick chain that scheduled this message. The App drops
+	// ticks whose epoch no longer matches the current one, so pausing/resuming
+	// cannot leave stale, overlapping tick chains running.
+	Epoch uint64
 }
 
 type ToggleAutoScrollMsg struct{}

--- a/internal/tui/store.go
+++ b/internal/tui/store.go
@@ -73,8 +73,9 @@ type Store interface {
 // Pass a Simulator to NewApp via WithSimulator to enable live data generation.
 type Simulator interface {
 	// ScheduleNextTick returns a tea.Cmd that, after a delay, sends a
-	// SimulationTickMsg for a random resource. Returns nil if no resources exist.
-	ScheduleNextTick() tea.Cmd
+	// SimulationTickMsg (tagged with epoch) for a random resource.
+	// Returns nil if no resources exist.
+	ScheduleNextTick(epoch uint64) tea.Cmd
 
 	// GenerateRevision creates a new simulated revision for the given resource.
 	GenerateRevision(rd *resource.Data) resource.Revision


### PR DESCRIPTION
Fixes from a concurrency review of the merged v2 TUI.

Three real bugs:
- `LiveStore.AddWatchKind` reused the unwatched-kinds slice in place, which corrupted the list the watch panel was still showing. It now allocates a fresh slice, and the getter/setter copy.
- Pausing and resuming the simulation while a tick was in flight left overlapping generators running, doubling the data rate each time. Ticks now carry an epoch and stale ones get dropped.
- Simulated revision IDs came from nanosecond bits plus rand and could collide, so the TUI sometimes treated different revisions as the same one. Now they use a monotonic counter.

Also returned copies from `KindGroups()`/`Timeline()`, moved the `ForEachResource` callback outside the lock, tagged the first simulated revision as ADDED, and added a nil-map guard.

Added tests for the adapter and simulation packages (neither had any). Passes `go test -race ./...`.

Not included: the timeline grows without bound over long runs. Fine for a demo, worth a follow-up.