### PR TITLE
fix(tui): keep watch manager open on add/remove, fix filter key conflicts

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -486,6 +486,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			len(a.store.StarredResources()),
 		)
 		a.setStatus(fmt.Sprintf("Now watching: %s (%d resources added)", msg.Kind.Kind, len(created)), false)
+		// Keep the watch manager in sync if it's still open.
+		if a.watchManager.IsVisible() {
+			a.watchManager.Refresh(a.store, a.store.UnwatchedKinds())
+		}
 
 	case RemoveWatchKindMsg:
 		count := a.store.ResourceCountByKind(msg.Kind)
@@ -513,6 +517,10 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			a.explorer.SetResource(nil)
 		}
 		a.setStatus(fmt.Sprintf("Unwatched: %s (%d resources removed)", msg.Kind, count), false)
+		// Keep the watch manager in sync if it's still open.
+		if a.watchManager.IsVisible() {
+			a.watchManager.Refresh(a.store, a.store.UnwatchedKinds())
+		}
 
 	case StatusMsg:
 		a.setStatus(msg.Text, msg.IsError)

--- a/internal/tui/command_palette.go
+++ b/internal/tui/command_palette.go
@@ -563,6 +563,34 @@ func (wm *WatchManager) Hide() {
 	wm.addQueryInput.Blur()
 }
 
+// Refresh repopulates the watched and available lists from the store without
+// resetting the active tab, filter text, or blurring inputs. Used after an
+// add/remove so the manager can stay open for further edits.
+func (wm *WatchManager) Refresh(store Store, unwatchedKinds []resource.Kind) {
+	kinds := store.WatchedKinds()
+	wm.watched = make([]watchedKindEntry, len(kinds))
+	wm.watchNames = make([]string, len(kinds))
+	for i, kind := range kinds {
+		wm.watched[i] = watchedKindEntry{
+			Kind:          kind,
+			ResourceCount: store.ResourceCountByKind(kind),
+			RevisionCount: store.RevisionCountByKind(kind),
+		}
+		wm.watchNames[i] = kind
+	}
+
+	wm.available = unwatchedKinds
+	wm.addNames = make([]string, len(unwatchedKinds))
+	for i, rk := range unwatchedKinds {
+		wm.addNames[i] = rk.Kind
+	}
+
+	// Re-run the fuzzy matches; fuzzyMatchAll clamps the cursor when the list
+	// shrank below the old cursor position.
+	wm.updateWatchMatches()
+	wm.updateAddMatches()
+}
+
 func (wm *WatchManager) updateWatchMatches() {
 	wm.watchMatches, wm.watchCursor = fuzzyMatchAll(wm.watchFilterInput.Value(), wm.watchNames, wm.watchCursor)
 }
@@ -612,29 +640,24 @@ func (wm *WatchManager) updateWatching(msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "up", "ctrl+p", "k":
+		case "up", "ctrl+p":
 			if wm.watchCursor > 0 {
 				wm.watchCursor--
 			}
-		case "down", "ctrl+n", "j":
+		case "down", "ctrl+n":
 			if wm.watchCursor < len(wm.watchMatches)-1 {
 				wm.watchCursor++
 			}
-		case "d", "delete":
+		case "enter", "delete":
 			if wm.watchCursor < len(wm.watchMatches) {
 				match := wm.watchMatches[wm.watchCursor]
 				if match.Index < len(wm.watched) {
 					entry := wm.watched[match.Index]
-					wm.Hide()
-					return tea.Batch(
-						Cmd(HideOverlayMsg{}),
-						Cmd(RemoveWatchKindMsg{Kind: entry.Kind}),
-					)
+					// Keep the manager open so several kinds can be removed in
+					// one session. The App refreshes our lists afterwards.
+					return Cmd(RemoveWatchKindMsg{Kind: entry.Kind})
 				}
 			}
-		case "enter":
-			wm.Hide()
-			return Cmd(HideOverlayMsg{})
 		default:
 			var cmd tea.Cmd
 			wm.watchFilterInput, cmd = wm.watchFilterInput.Update(msg)
@@ -666,11 +689,9 @@ func (wm *WatchManager) updateAdd(msg tea.Msg) tea.Cmd {
 				match := wm.addMatches[wm.addCursor]
 				if match.Index < len(wm.available) {
 					rk := wm.available[match.Index]
-					wm.Hide()
-					return tea.Batch(
-						Cmd(HideOverlayMsg{}),
-						Cmd(AddWatchKindMsg{Kind: rk}),
-					)
+					// Keep the manager open so several kinds can be added in one
+					// session. The App refreshes our lists afterwards.
+					return Cmd(AddWatchKindMsg{Kind: rk})
 				}
 			}
 		default:
@@ -729,7 +750,7 @@ func (wm *WatchManager) View() string {
 	// Footer
 	var footerText string
 	if wm.tab == wmTabWatching {
-		footerText = fmt.Sprintf("  %d types watched  Tab:add types  d:unwatch  Esc:close",
+		footerText = fmt.Sprintf("  %d types watched  Tab:add types  Enter:unwatch  Esc:close",
 			len(wm.watchMatches))
 	} else {
 		footerText = fmt.Sprintf("  %d types available  Tab:back  Enter:add  Esc:close",

--- a/internal/tui/watch_manager_test.go
+++ b/internal/tui/watch_manager_test.go
@@ -1,0 +1,106 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/loog-project/loog/internal/resource"
+)
+
+func runCmd(cmd tea.Cmd) tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	return cmd()
+}
+
+// TestWatchManager_UnwatchStaysOpen verifies that unwatching a type emits a
+// RemoveWatchKindMsg and keeps the manager open for further edits.
+func TestWatchManager_UnwatchStaysOpen(t *testing.T) {
+	wm := NewWatchManager(CatppuccinMocha)
+	wm.SetSize(120, 40)
+	wm.Show(newDataStore(), nil) // watched: Deployment, Service
+
+	msg := runCmd(wm.updateWatching(tea.KeyMsg{Type: tea.KeyEnter}))
+	rm, ok := msg.(RemoveWatchKindMsg)
+	if !ok {
+		t.Fatalf("expected RemoveWatchKindMsg, got %T", msg)
+	}
+	if rm.Kind == "" {
+		t.Error("RemoveWatchKindMsg has empty kind")
+	}
+	if !wm.IsVisible() {
+		t.Error("watch manager should stay open after unwatch")
+	}
+}
+
+// TestWatchManager_AddStaysOpen verifies that adding a type emits an
+// AddWatchKindMsg and keeps the manager open.
+func TestWatchManager_AddStaysOpen(t *testing.T) {
+	wm := NewWatchManager(CatppuccinMocha)
+	wm.SetSize(120, 40)
+	unwatched := []resource.Kind{
+		{Kind: "ConfigMap", APIVersion: "v1", Resource: "configmaps", Namespaced: true},
+	}
+	wm.Show(newDataStore(), unwatched)
+	// Move to the Add tab.
+	wm.Update(tea.KeyMsg{Type: tea.KeyTab})
+
+	msg := runCmd(wm.updateAdd(tea.KeyMsg{Type: tea.KeyEnter}))
+	add, ok := msg.(AddWatchKindMsg)
+	if !ok {
+		t.Fatalf("expected AddWatchKindMsg, got %T", msg)
+	}
+	if add.Kind.Kind != "ConfigMap" {
+		t.Errorf("added kind = %q, want ConfigMap", add.Kind.Kind)
+	}
+	if !wm.IsVisible() {
+		t.Error("watch manager should stay open after add")
+	}
+}
+
+// TestWatchManager_FilterAcceptsLetterKeys verifies that typing letters that
+// used to be action shortcuts (d, j, k) filters instead of triggering actions.
+func TestWatchManager_FilterAcceptsLetterKeys(t *testing.T) {
+	wm := NewWatchManager(CatppuccinMocha)
+	wm.SetSize(120, 40)
+	wm.Show(newDataStore(), nil)
+
+	for _, r := range []rune{'d', 'j', 'k'} {
+		msg := runCmd(wm.updateWatching(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}}))
+		if _, ok := msg.(RemoveWatchKindMsg); ok {
+			t.Fatalf("typing %q triggered unwatch instead of filtering", string(r))
+		}
+	}
+	if got := wm.watchFilterInput.Value(); got != "djk" {
+		t.Errorf("filter value = %q, want %q", got, "djk")
+	}
+	if !wm.IsVisible() {
+		t.Error("watch manager should stay open while filtering")
+	}
+}
+
+// TestWatchManager_RefreshPreservesTabAndFilter verifies Refresh repopulates
+// lists without resetting the active tab or filter text.
+func TestWatchManager_RefreshPreservesTabAndFilter(t *testing.T) {
+	wm := NewWatchManager(CatppuccinMocha)
+	wm.SetSize(120, 40)
+	wm.Show(newDataStore(), nil)
+	wm.Update(tea.KeyMsg{Type: tea.KeyTab}) // Add tab
+	wm.addQueryInput.SetValue("cm")
+
+	wm.Refresh(newDataStore(), []resource.Kind{
+		{Kind: "ConfigMap", APIVersion: "v1", Resource: "configmaps", Namespaced: true},
+	})
+
+	if wm.tab != wmTabAdd {
+		t.Error("Refresh should preserve the active tab")
+	}
+	if wm.addQueryInput.Value() != "cm" {
+		t.Error("Refresh should preserve the filter text")
+	}
+	if len(wm.addNames) != 1 || wm.addNames[0] != "ConfigMap" {
+		t.Errorf("Refresh did not update available kinds: %v", wm.addNames)
+	}
+}


### PR DESCRIPTION
Two watch manager issues you hit before the demo.

The manager closed after adding or removing a single kind, so managing several types meant reopening it each time. It now stays open and refreshes its lists in place.

The bigger one: on the Watching tab, `d`/`delete` were bound to unwatch and `j`/`k` to navigation, but the filter input is always focused. So typing those letters triggered actions instead of filtering. Most kind names contain a `d` (Deployment, Pod, ConfigMap), which made the filter nearly unusable. Navigation is now arrows / ctrl-n / ctrl-p only, and unwatch is `enter` or `delete`, matching the Add tab where `enter` adds.

Added tests for the behavior. Passes `go test -race ./...`.