### PR TITLE
fix: sweep of concurrency, TUI, store, and diff bugs

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -117,10 +118,11 @@ func loadClusterResourceKinds(kubeConfigPath string) ([]resource.Kind, error) {
 	lists, err := cs.Discovery().ServerPreferredResources()
 	if err != nil {
 		// Discovery can return partial results on errors (e.g. metrics-server unavailable).
-		// Use whatever we got if lists is non-nil.
+		// Use whatever we got if lists is non-nil, but surface the partial failure.
 		if lists == nil {
 			return nil, fmt.Errorf("getting server preferred resources: %w", err)
 		}
+		log.Warn().Err(err).Msg("Partial resource discovery; some resource types may be missing")
 	}
 
 	var kinds []resource.Kind

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -261,14 +261,21 @@ func setupProduction(ctx context.Context, args []string) (
 		if fileErr != nil {
 			return cleanup, nil, nil, nil, nil, fmt.Errorf("cannot create temp file: %w", fileErr)
 		}
-		cleanups = append(cleanups, func() {
-			_ = file.Close()
-			if removeErr := os.Remove(file.Name()); removeErr != nil {
-				setupLog.Err(removeErr).Msg("Cannot remove temp file")
-			}
-		})
 		outputFile = file.Name()
-		setupLog.Info().Msgf("No output file specified, using temporary file: %s", outputFile)
+		_ = file.Close() // bbolt reopens by path
+
+		if headlessMode {
+			// In headless mode the collected file IS the deliverable, so keep
+			// it and tell the user where it landed instead of deleting it.
+			setupLog.Info().Msgf("No output file specified; collecting to: %s", outputFile)
+		} else {
+			cleanups = append(cleanups, func() {
+				if removeErr := os.Remove(outputFile); removeErr != nil {
+					setupLog.Err(removeErr).Msg("Cannot remove temp file")
+				}
+			})
+			setupLog.Info().Msgf("No output file specified, using temporary file: %s", outputFile)
+		}
 	}
 
 	setupLog.Info().
@@ -341,6 +348,7 @@ func runHeadless(
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(c)
 	<-c
 
 	setupLog.Info().Msg("Received interrupt signal, stopping collector...")
@@ -369,11 +377,17 @@ func runInteractive(
 					log.Error().Err(err).Str("gvr", rk.GVR()).Msg("Cannot parse GVR for watch add")
 					return
 				}
-				if err := m.Add(gvr); err != nil {
-					log.Error().Err(err).Str("kind", rk.Kind).Msg("Cannot add watch to mux")
-				} else {
-					log.Info().Str("kind", rk.Kind).Str("gvr", rk.GVR()).Msg("Added dynamic watch")
-				}
+				// m.Add blocks until the informer's cache syncs. This callback
+				// runs on the bubbletea event loop, so blocking here would
+				// freeze the whole UI (indefinitely if the GVR never syncs).
+				// Run it in the background; events arrive via the collector.
+				go func() {
+					if err := m.Add(gvr); err != nil {
+						log.Error().Err(err).Str("kind", rk.Kind).Msg("Cannot add watch to mux")
+					} else {
+						log.Info().Str("kind", rk.Kind).Str("gvr", rk.GVR()).Msg("Added dynamic watch")
+					}
+				}()
 			},
 			func(kind string) {
 				log.Info().Str("kind", kind).Msg("Watch kind removed from TUI (mux removal requires GVR)")
@@ -385,10 +399,17 @@ func runInteractive(
 	// Redirect klog (k8s client-go) into the TUI's debug log viewer
 	logCapture := &tuiLogWriter{program: program}
 	klog.SetOutput(logCapture)
+	// Stop routing klog into the (dead) program once the TUI exits.
+	defer klog.SetOutput(io.Discard)
+
 	savedStderr := os.Stderr
-	devNull, _ := os.Open(os.DevNull)
-	if devNull != nil {
+	if devNull, derr := os.Open(os.DevNull); derr == nil {
 		os.Stderr = devNull
+		// Deferred so stderr is restored and the fd closed even if program.Run panics.
+		defer func() {
+			os.Stderr = savedStderr
+			_ = devNull.Close()
+		}()
 	}
 
 	// Discover cluster resource kinds in the background for WatchManager
@@ -422,12 +443,7 @@ func runInteractive(
 	}()
 
 	if _, teaErr := program.Run(); teaErr != nil {
-		os.Stderr = savedStderr
 		setupLog.Error().Err(teaErr).Msg("Error running TUI program")
-	}
-	os.Stderr = savedStderr
-	if devNull != nil {
-		_ = devNull.Close()
 	}
 
 	setupLog.Info().Msg("TUI program exited, stopping collector")

--- a/internal/resource/analysis.go
+++ b/internal/resource/analysis.go
@@ -142,7 +142,7 @@ type LoopInfo struct {
 // state appears more than once (indicating a reconcile loop).
 func (rd *Data) DetectLoop(windowSize int) bool {
 	revs := rd.Revisions
-	if len(revs) < 3 {
+	if len(revs) < 3 || windowSize <= 0 {
 		return false
 	}
 	start := max(len(revs)-windowSize, 0)
@@ -165,10 +165,22 @@ func (rd *Data) DetectLoop(windowSize int) bool {
 	return false
 }
 
+// loopLabel maps a zero-based state index to a spreadsheet-style label:
+// 0->A, 25->Z, 26->AA, 27->AB, ... so more than 26 distinct loop states
+// still get unique labels instead of all collapsing onto "Z".
+func loopLabel(i int) string {
+	s := ""
+	for i >= 0 {
+		s = string(rune('A'+i%26)) + s
+		i = i/26 - 1
+	}
+	return s
+}
+
 // AnalyzeLoop performs detailed loop analysis on recent revisions.
 func (rd *Data) AnalyzeLoop(windowSize int) LoopInfo {
 	revs := rd.Revisions
-	if len(revs) < 4 {
+	if len(revs) < 4 || windowSize <= 0 {
 		return LoopInfo{}
 	}
 	start := max(len(revs)-windowSize, 0)
@@ -206,18 +218,14 @@ func (rd *Data) AnalyzeLoop(windowSize int) LoopInfo {
 
 	// Build label map: only states appearing 2+ times are loop participants
 	loopRevs := make(map[RevisionID]string)
-	nextLabel := 'A'
 	labelMap := make(map[string]string)
 	distinctStates := 0
 	for _, fp := range fingerOrder {
 		occ := seen[fp]
 		if occ.count >= 2 {
-			label := string(nextLabel)
+			label := loopLabel(distinctStates)
 			labelMap[fp] = label
 			distinctStates++
-			if nextLabel < 'Z' {
-				nextLabel++
-			}
 			for _, rid := range occ.revs {
 				loopRevs[rid] = label
 			}
@@ -243,15 +251,18 @@ func (rd *Data) AnalyzeLoop(windowSize int) LoopInfo {
 	}
 	cycles := transitions / 2
 
-	// Calculate cycle period from the most frequently occurring state
+	// Calculate cycle period from the most frequently occurring state.
+	// Iterate fingerOrder (deterministic) rather than the seen map so ties
+	// resolve consistently across runs.
 	var period time.Duration
 	var firstSeen time.Time
 	var bestTimes []time.Time
 	bestCount := 0
-	for fp, occ := range seen {
+	for _, fp := range fingerOrder {
 		if _, isLoop := labelMap[fp]; !isLoop {
 			continue
 		}
+		occ := seen[fp]
 		if occ.count > bestCount {
 			bestCount = occ.count
 			bestTimes = occ.times

--- a/internal/resource/bugsweep_test.go
+++ b/internal/resource/bugsweep_test.go
@@ -1,0 +1,79 @@
+package resource
+
+import (
+	"testing"
+	"time"
+)
+
+func TestLoopLabel(t *testing.T) {
+	cases := map[int]string{
+		0: "A", 1: "B", 25: "Z", 26: "AA", 27: "AB", 51: "AZ", 52: "BA",
+	}
+	for i, want := range cases {
+		if got := loopLabel(i); got != want {
+			t.Errorf("loopLabel(%d) = %q, want %q", i, got, want)
+		}
+	}
+	// All labels for 0..100 must be unique (regression for the old ">25 -> Z" bug).
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		l := loopLabel(i)
+		if seen[l] {
+			t.Fatalf("loopLabel produced duplicate label %q at %d", l, i)
+		}
+		seen[l] = true
+	}
+}
+
+func TestDetectLoopNegativeWindowNoPanic(t *testing.T) {
+	rd := &Data{Revisions: []Revision{
+		{ID: 1, Object: map[string]any{"a": 1}},
+		{ID: 2, Object: map[string]any{"a": 2}},
+		{ID: 3, Object: map[string]any{"a": 1}},
+	}}
+	// Must not panic and must return false for a non-positive window.
+	if rd.DetectLoop(-5) {
+		t.Error("DetectLoop(-5) should be false")
+	}
+	if rd.DetectLoop(0) {
+		t.Error("DetectLoop(0) should be false")
+	}
+}
+
+func TestAnalyzeLoopNegativeWindowNoPanic(t *testing.T) {
+	rd := &Data{Revisions: []Revision{
+		{ID: 1, Time: time.Now(), Object: map[string]any{"a": 1}},
+		{ID: 2, Time: time.Now(), Object: map[string]any{"a": 2}},
+		{ID: 3, Time: time.Now(), Object: map[string]any{"a": 1}},
+		{ID: 4, Time: time.Now(), Object: map[string]any{"a": 2}},
+	}}
+	got := rd.AnalyzeLoop(-1)
+	if got.IsLoop {
+		t.Error("AnalyzeLoop(-1) should report no loop")
+	}
+}
+
+func TestCloneMapDeepClonesNestedTypes(t *testing.T) {
+	orig := map[string]any{
+		"scalar": "x",
+		"nested": map[string]any{"n": 1},
+		"list":   []any{map[string]any{"a": 1}, "s"},
+		"maps":   []map[string]any{{"k": "v"}},
+	}
+	clone := CloneMap(orig)
+
+	// Mutate the clone's nested structures; the original must not change.
+	clone["nested"].(map[string]any)["n"] = 99
+	clone["list"].([]any)[0].(map[string]any)["a"] = 99
+	clone["maps"].([]map[string]any)[0]["k"] = "changed"
+
+	if orig["nested"].(map[string]any)["n"] != 1 {
+		t.Error("nested map was not deep-cloned")
+	}
+	if orig["list"].([]any)[0].(map[string]any)["a"] != 1 {
+		t.Error("[]any element was not deep-cloned")
+	}
+	if orig["maps"].([]map[string]any)[0]["k"] != "v" {
+		t.Error("[]map[string]any element was not deep-cloned")
+	}
+}

--- a/internal/resource/helpers.go
+++ b/internal/resource/helpers.go
@@ -92,37 +92,46 @@ func GroupTimelineByBurst(entries []TimelineEntry, window time.Duration) []any {
 }
 
 // CloneMap performs a recursive clone of a map[string]any.
-// It recursively clones nested maps and slices, but shares scalar values.
+// It recursively clones nested maps and slices, but shares scalar values
+// (which are immutable in Go). Non-JSON collection shapes other than
+// map[string]any, []any, and []map[string]any are shared by reference; this
+// is safe for the unstructured Kubernetes objects loog handles, which decode
+// only into those shapes.
 func CloneMap(m map[string]any) map[string]any {
 	if m == nil {
 		return nil
 	}
 	result := make(map[string]any, len(m))
 	for k, v := range m {
-		switch val := v.(type) {
-		case map[string]any:
-			result[k] = CloneMap(val)
-		case []any:
-			result[k] = cloneSlice(val)
-		default:
-			result[k] = v
-		}
+		result[k] = cloneValue(v)
 	}
 	return result
+}
+
+// cloneValue deep-clones the collection shapes loog can encounter; everything
+// else (scalars) is returned as-is.
+func cloneValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		return CloneMap(val)
+	case []any:
+		return cloneSlice(val)
+	case []map[string]any:
+		cloned := make([]map[string]any, len(val))
+		for i, item := range val {
+			cloned[i] = CloneMap(item)
+		}
+		return cloned
+	default:
+		return v
+	}
 }
 
 // cloneSlice recursively clones a []any, handling nested maps and slices.
 func cloneSlice(s []any) []any {
 	cloned := make([]any, len(s))
 	for i, item := range s {
-		switch v := item.(type) {
-		case map[string]any:
-			cloned[i] = CloneMap(v)
-		case []any:
-			cloned[i] = cloneSlice(v)
-		default:
-			cloned[i] = item
-		}
+		cloned[i] = cloneValue(item)
 	}
 	return cloned
 }

--- a/internal/service/cache.go
+++ b/internal/service/cache.go
@@ -108,6 +108,10 @@ func (c *stateCache) get(uid string) *trackerState {
 // If the cache is at capacity, existing entries can still be updated but
 // new entries are dropped.
 func (c *stateCache) set(uid string, ts *trackerState) {
+	// Stamp lastRead before publishing the entry. If it stayed 0 until after
+	// the map insert, a janitor tick landing in that window would compute a
+	// decades-long age and evict the just-inserted hot entry.
+	atomic.StoreInt64(&ts.lastRead, time.Now().UnixNano())
 	c.mu.Lock()
 	_, exists := c.data[uid]
 	if !exists && len(c.data) >= maxTrackedEntries {
@@ -117,5 +121,4 @@ func (c *stateCache) set(uid string, ts *trackerState) {
 	}
 	c.data[uid] = ts
 	c.mu.Unlock()
-	atomic.StoreInt64(&ts.lastRead, time.Now().UnixNano())
 }

--- a/internal/service/tracker_service.go
+++ b/internal/service/tracker_service.go
@@ -91,9 +91,7 @@ func (t *TrackerService) Commit(
 	objID string,
 	newObject *unstructured.Unstructured,
 ) (store.RevisionID, error) {
-	lw := t.objLock(objID)
-	lw.mu.Lock()
-	atomic.StoreInt64(&lw.lastUse, time.Now().UnixNano())
+	lw := t.lockObject(objID)
 	defer lw.mu.Unlock()
 
 	// try to hot-state cache
@@ -223,6 +221,14 @@ func (t *TrackerService) Restore(
 
 		if p != nil {
 			patchChain = append(patchChain, p)
+			// Guard against a corrupted chain: PreviousID must strictly
+			// decrease toward the base snapshot. A self-reference or cycle
+			// would otherwise loop forever and grow patchChain without bound.
+			if p.PreviousID >= currentRevision {
+				return nil, fmt.Errorf(
+					"corrupted patch chain for %s: revision %d points back to %d",
+					objID, currentRevision, p.PreviousID)
+			}
 			currentRevision = p.PreviousID
 
 			continue // find the next patch / snapshot
@@ -264,20 +270,50 @@ func (t *TrackerService) objLock(uid string) *lockWrap {
 		return mu
 	}
 	t.commitLockMutex.Lock()
+	defer t.commitLockMutex.Unlock()
+	if t.commitLocks == nil {
+		// Service is closed. Hand back a standalone lock so callers don't panic
+		// writing to a nil map; the janitor is stopped so there's no contention.
+		return &lockWrap{lastUse: time.Now().UnixNano()}
+	}
 	if mu = t.commitLocks[uid]; mu == nil {
-		mu = &lockWrap{}
+		// Stamp lastUse at creation so a brand-new lock isn't immediately
+		// eligible for janitor eviction (lastUse == 0 would always look stale).
+		mu = &lockWrap{lastUse: time.Now().UnixNano()}
 		t.commitLocks[uid] = mu
 	}
-	t.commitLockMutex.Unlock()
 	return mu
+}
+
+// lockObject acquires the per-object commit lock and guards against the janitor
+// evicting the lock (and another goroutine installing a fresh one) in the window
+// between lookup and Lock. Without this, two commits for the same object could
+// run concurrently on the same cached trackerState. The caller must Unlock the
+// returned lock.
+func (t *TrackerService) lockObject(uid string) *lockWrap {
+	for {
+		lw := t.objLock(uid)
+		lw.mu.Lock()
+
+		t.commitLockMutex.RLock()
+		current, tracked := t.commitLocks[uid]
+		closed := t.commitLocks == nil
+		t.commitLockMutex.RUnlock()
+
+		if closed || (tracked && current == lw) {
+			atomic.StoreInt64(&lw.lastUse, time.Now().UnixNano())
+			return lw
+		}
+		// The lock we grabbed was evicted; retry with the current one.
+		lw.mu.Unlock()
+	}
 }
 
 func (t *TrackerService) WarmCache(uid string, obj diffmap.DiffMap, rev store.RevisionID) {
 	if t.cache == nil {
 		return
 	}
-	lock := t.objLock(uid)
-	lock.mu.Lock()
+	lock := t.lockObject(uid)
 	defer lock.mu.Unlock()
 	t.cache.set(uid, &trackerState{obj: obj, rev: rev})
 }

--- a/internal/store/bbolt/bugsweep_test.go
+++ b/internal/store/bbolt/bugsweep_test.go
@@ -1,0 +1,28 @@
+package bbolt
+
+import (
+	"testing"
+	"time"
+)
+
+// Close must be idempotent even when a periodic sync goroutine is running,
+// and must not panic on a second call (previously close-of-closed-channel).
+func TestStore_CloseIdempotentWithSync(t *testing.T) {
+	s, err := NewWithOptions(t.TempDir()+"/db.bb", Options{
+		Durable:      true,
+		SyncInterval: 5 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	// Let the sync goroutine tick at least once.
+	time.Sleep(15 * time.Millisecond)
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	// Second Close must be a no-op, not a panic.
+	if err := s.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}

--- a/internal/store/bbolt/store.go
+++ b/internal/store/bbolt/store.go
@@ -54,7 +54,9 @@ type Store struct {
 
 	compress bool
 
-	stopSync chan struct{} // nil when no periodic sync
+	stopSync  chan struct{} // nil when no periodic sync
+	syncDone  chan struct{} // closed by syncLoop when it returns
+	closeOnce sync.Once
 }
 
 var _ store.ResourcePatchStore = (*Store)(nil)
@@ -113,6 +115,7 @@ func NewWithOptions(path string, opts Options) (*Store, error) {
 	// Start periodic sync goroutine if configured.
 	if opts.Durable && opts.SyncInterval > 0 {
 		s.stopSync = make(chan struct{})
+		s.syncDone = make(chan struct{})
 		go s.syncLoop(opts.SyncInterval)
 	}
 
@@ -121,6 +124,7 @@ func NewWithOptions(path string, opts Options) (*Store, error) {
 
 // syncLoop calls db.Sync() at the given interval until stopSync is closed.
 func (s *Store) syncLoop(interval time.Duration) {
+	defer close(s.syncDone)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
@@ -135,14 +139,21 @@ func (s *Store) syncLoop(interval time.Duration) {
 	}
 }
 
-// Close flushes any pending writes and closes the database.
+// Close flushes any pending writes and closes the database. It is idempotent.
 func (s *Store) Close() error {
-	if s.stopSync != nil {
-		close(s.stopSync)
-	}
-	// Always do a final sync to make sure everything is on disk.
-	if err := s.db.Sync(); err != nil {
-		log.Error().Err(err).Msg("Error syncing database before closing")
-	}
-	return s.db.Close()
+	var err error
+	s.closeOnce.Do(func() {
+		if s.stopSync != nil {
+			close(s.stopSync)
+			// Wait for syncLoop to return so it can't call db.Sync()
+			// concurrently with db.Close().
+			<-s.syncDone
+		}
+		// Always do a final sync to make sure everything is on disk.
+		if syncErr := s.db.Sync(); syncErr != nil {
+			log.Error().Err(syncErr).Msg("Error syncing database before closing")
+		}
+		err = s.db.Close()
+	})
+	return err
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -999,18 +999,25 @@ func (a *App) refreshViewsAfterNewRevision(resourceUID string) {
 		len(a.store.StarredResources()),
 	)
 
-	// Auto-scroll: jump to newest if enabled
-	if a.autoScroll {
-		// Explorer: only jump if the selected resource got the new revision
-		selectedUID := a.explorer.tree.SelectedUID()
-		if selectedUID == resourceUID {
-			rd := a.store.GetResource(resourceUID)
-			if rd != nil && len(rd.Revisions) > 0 {
+	// The store is copy-on-write: appending a revision swaps in a brand-new
+	// *resource.Data, so the panels still hold the pre-append pointer. If the
+	// selected resource received this revision, rebind the middle and detail
+	// panels to the fresh copy so they don't show stale data. This must happen
+	// whether or not auto-scroll is on.
+	selectedUID := a.explorer.tree.SelectedUID()
+	if selectedUID == resourceUID {
+		if rd := a.store.GetResource(resourceUID); rd != nil && len(rd.Revisions) > 0 {
+			a.explorer.revList.SetResource(rd)
+			if a.autoScroll {
 				a.explorer.revList.JumpToNewest()
-				a.explorer.detail.SetRevision(rd, len(rd.Revisions)-1)
 			}
+			idx, _ := a.explorer.revList.CursorInfo()
+			a.explorer.detail.SetRevision(rd, idx)
 		}
-		// Timeline: always jump to newest
+	}
+
+	// Timeline: always jump to newest when auto-scroll is enabled.
+	if a.autoScroll {
 		a.timeline.timeline.JumpToNewest()
 		if entry := a.timeline.timeline.SelectedEntry(); entry != nil {
 			a.timeline.SelectEntry(*entry)

--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -310,6 +310,20 @@ func (rt *ResourceTree) handleFilterMsg(msg tea.Msg) tea.Cmd {
 }
 
 func (rt *ResourceTree) buildItems() {
+	// Remember what the cursor points at so we can restore it after the
+	// rebuild. rt.selected only tracks resources, so a live refresh would
+	// otherwise yank the cursor off a kind header back onto the selected
+	// resource. Capture the header/resource identity before we discard items.
+	var cursorUID, cursorKind string
+	hadCursorItem := rt.cursor >= 0 && rt.cursor < len(rt.items)
+	if hadCursorItem {
+		ci := rt.items[rt.cursor]
+		cursorKind = ci.Kind
+		if ci.Type == treeItemResource && ci.Resource != nil {
+			cursorUID = ci.Resource.Resource.UID
+		}
+	}
+
 	rt.items = nil
 	// When filter is applied and NOT being edited, hide non-matching items.
 	// During editing (even with a previously applied filter), show everything for preview.
@@ -353,8 +367,25 @@ func (rt *ResourceTree) buildItems() {
 		}
 	}
 
-	// After rebuilding, try to re-locate the selected UID so the cursor
-	// stays on the correct item even if item order changed.
+	// Restore the cursor to the same item it was on before the rebuild
+	// (resource or kind header), so live refreshes don't move it.
+	if hadCursorItem {
+		for i, item := range rt.items {
+			if cursorUID != "" {
+				if item.Type == treeItemResource && item.Resource != nil &&
+					item.Resource.Resource.UID == cursorUID {
+					rt.cursor = i
+					return
+				}
+			} else if item.Type == treeItemKind && item.Kind == cursorKind {
+				rt.cursor = i
+				return
+			}
+		}
+	}
+
+	// The prior cursor item is gone (or this is the first build): fall back to
+	// the selected resource so selection stays visible.
 	if rt.selected != "" {
 		for i, item := range rt.items {
 			if item.Type == treeItemResource && item.Resource != nil && item.Resource.Resource.UID == rt.selected {
@@ -364,9 +395,12 @@ func (rt *ResourceTree) buildItems() {
 		}
 	}
 
-	// Fallback: clamp cursor if selected UID wasn't found (e.g. collapsed group)
+	// Clamp into range.
 	if rt.cursor >= len(rt.items) && len(rt.items) > 0 {
 		rt.cursor = len(rt.items) - 1
+	}
+	if rt.cursor < 0 {
+		rt.cursor = 0
 	}
 }
 
@@ -1604,6 +1638,10 @@ func (tl *TimelineList) rebuild() {
 	}
 
 	if tl.reversed {
+		// Reverse a copy: when no window/filter is active, `filtered` still
+		// aliases tl.entries, and reversing in place would corrupt the source
+		// slice (and break the second toggle back to newest-first).
+		filtered = slices.Clone(filtered)
 		slices.Reverse(filtered)
 	}
 
@@ -1807,7 +1845,7 @@ func (tl *TimelineList) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (tl *TimelineList) selectCurrent() tea.Cmd {
-	if tl.cursor >= len(tl.flatItems) {
+	if tl.cursor < 0 || tl.cursor >= len(tl.flatItems) {
 		return nil
 	}
 	item := tl.flatItems[tl.cursor]
@@ -1920,8 +1958,10 @@ func (tl *TimelineList) View() string {
 		kindPrefix := e.Resource.Kind + "/"
 		nameStr := e.Resource.Name
 		combined := kindPrefix + nameStr
-		if len(combined) > nameMaxW {
-			nameStr = Truncate(nameStr, nameMaxW-len(kindPrefix))
+		// Use display width (rune-aware) rather than byte length so multibyte
+		// names aren't over-truncated or dropped entirely.
+		if lipgloss.Width(combined) > nameMaxW {
+			nameStr = Truncate(nameStr, nameMaxW-lipgloss.Width(kindPrefix))
 		}
 		var kindName string
 		if isDimmed {

--- a/pkg/diffpreview/bugsweep_test.go
+++ b/pkg/diffpreview/bugsweep_test.go
@@ -1,0 +1,66 @@
+package diffpreview
+
+import (
+	"strings"
+	"testing"
+)
+
+// Empty collections must not render as "null".
+
+func TestRender_EmptyListNotNull(t *testing.T) {
+	node := &AnnotatedNode{
+		Children: map[string]*AnnotatedNode{
+			"items": buildFullNode([]any{}, Unchanged),
+		},
+	}
+	out := RenderYAML(node, plainTheme, plainOpts)
+	assertContains(t, out, "items: []")
+	if strings.Contains(out, "null") {
+		t.Errorf("empty list rendered as null:\n%s", out)
+	}
+}
+
+func TestRender_EmptyMapNotNull(t *testing.T) {
+	node := &AnnotatedNode{
+		Children: map[string]*AnnotatedNode{
+			"meta": {Change: Unchanged, Children: map[string]*AnnotatedNode{}},
+		},
+	}
+	out := RenderYAML(node, plainTheme, plainOpts)
+	assertContains(t, out, "meta: {}")
+}
+
+// Integer types other than int should still be number-styled / rendered.
+
+func TestRender_IntegerTypes(t *testing.T) {
+	node := &AnnotatedNode{
+		Children: map[string]*AnnotatedNode{
+			"i64": {Value: int64(42), Change: Unchanged},
+			"i32": {Value: int32(7), Change: Unchanged},
+			"u64": {Value: uint64(9), Change: Unchanged},
+		},
+	}
+	out := RenderYAML(node, plainTheme, plainOpts)
+	assertContains(t, out, "i64: 42")
+	assertContains(t, out, "i32: 7")
+	assertContains(t, out, "u64: 9")
+}
+
+// A keyed list that also contains scalar elements in b must not drop those
+// scalars from the diff.
+func TestDiff_KeyedListKeepsScalarAdditions(t *testing.T) {
+	a := map[string]any{
+		"ports": []any{
+			map[string]any{"name": "http", "port": float64(80)},
+		},
+	}
+	b := map[string]any{
+		"ports": []any{
+			map[string]any{"name": "http", "port": float64(80)},
+			"extra-scalar",
+		},
+	}
+	node := Diff(a, b)
+	out := RenderYAML(node, plainTheme, plainOpts)
+	assertContains(t, out, "extra-scalar")
+}

--- a/pkg/diffpreview/diff.go
+++ b/pkg/diffpreview/diff.go
@@ -134,14 +134,11 @@ func diffListByKey(a, b []any, matchKey string) []*AnnotatedNode {
 		return ""
 	}
 
-	// Index b elements by their match-key value while preserving order.
+	// Index b's keyed elements by their match-key value.
 	bByKey := make(map[string]any, len(b))
-	var bOrder []string
 	for _, item := range b {
-		k := keyOf(item)
-		if k != "" {
+		if k := keyOf(item); k != "" {
 			bByKey[k] = item
-			bOrder = append(bOrder, k)
 		}
 	}
 
@@ -163,10 +160,13 @@ func diffListByKey(a, b []any, matchKey string) []*AnnotatedNode {
 		result = append(result, diffValues(item, bItem))
 	}
 
-	// Append elements from b that had no match in a.
-	for _, k := range bOrder {
-		if !matched[k] {
-			result = append(result, buildFullNode(bByKey[k], Added))
+	// Append b elements that had no match in a, in b's original order. This
+	// includes keyless items (e.g. scalars mixed into a keyed list), which
+	// would otherwise be dropped from the diff entirely.
+	for _, item := range b {
+		k := keyOf(item)
+		if k == "" || !matched[k] {
+			result = append(result, buildFullNode(item, Added))
 		}
 	}
 	return result
@@ -201,7 +201,10 @@ func buildFullNode(val any, change ChangeType) *AnnotatedNode {
 		}
 		return node
 	case []any:
-		node := &AnnotatedNode{Change: change}
+		// Use a non-nil slice so an empty list is still rendered as a list
+		// ("[]") rather than falling through to the scalar leaf and printing
+		// "null".
+		node := &AnnotatedNode{Change: change, List: make([]*AnnotatedNode, 0, len(v))}
 		for _, item := range v {
 			node.List = append(node.List, buildFullNode(item, change))
 		}

--- a/pkg/diffpreview/renderer.go
+++ b/pkg/diffpreview/renderer.go
@@ -63,6 +63,10 @@ func (r *renderer) renderList(items []*AnnotatedNode, level int, parentChange Ch
 		case item.Children != nil:
 			r.renderListMapItem(item.Children, prefix, dash, level, change)
 		case item.List != nil:
+			if len(item.List) == 0 {
+				r.sb.WriteString(prefix + dash + "[]\n")
+				break
+			}
 			r.sb.WriteString(prefix + dash + "\n")
 			r.renderList(item.List, level+1, change)
 		default:
@@ -98,9 +102,17 @@ func (r *renderer) renderListMapItem(children map[string]*AnnotatedNode, prefix,
 func (r *renderer) renderChildValue(child *AnnotatedNode, level int) {
 	switch {
 	case child.List != nil:
+		if len(child.List) == 0 {
+			r.sb.WriteString(" []\n")
+			return
+		}
 		r.sb.WriteString("\n")
 		r.renderList(child.List, level+1, child.Change)
 	case child.Children != nil:
+		if len(child.Children) == 0 {
+			r.sb.WriteString(" {}\n")
+			return
+		}
 		r.sb.WriteString("\n")
 		r.renderMap(child.Children, level+1)
 	default:
@@ -129,7 +141,9 @@ func (r *renderer) syntaxHighlight(val any) string {
 		return r.theme.BoolStyle.Render(fmt.Sprintf("%v", v))
 	case int:
 		return r.theme.NumberStyle.Render(fmt.Sprintf("%d", v))
-	case float64:
+	case int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return r.theme.NumberStyle.Render(fmt.Sprintf("%d", v))
+	case float32, float64:
 		return r.theme.NumberStyle.Render(fmt.Sprintf("%v", v))
 	case nil:
 		return r.theme.NullStyle.Render("null")

--- a/pkg/mux/mux.go
+++ b/pkg/mux/mux.go
@@ -80,8 +80,15 @@ type Mux struct {
 	wg     sync.WaitGroup // tracks in-flight dispatch calls
 
 	mu      sync.RWMutex
-	watches map[schema.GroupVersionResource]context.CancelFunc
+	watches map[schema.GroupVersionResource]*watchEntry
 	stopped bool
+}
+
+// watchEntry holds the per-GVR cancel func and a channel that is closed once
+// the initial Add for that GVR has finished (whether it synced or failed).
+type watchEntry struct {
+	cancel context.CancelFunc
+	synced chan struct{}
 }
 
 // New creates a Mux that will create informers using the provided
@@ -108,29 +115,46 @@ func New(ctx context.Context, client dynamic.Interface, opts ...Option) (*Mux, e
 		client:  client,
 		cfg:     cfg,
 		events:  make(chan watch.Event, cfg.buffer),
-		watches: make(map[schema.GroupVersionResource]context.CancelFunc),
+		watches: make(map[schema.GroupVersionResource]*watchEntry),
 	}, nil
 }
 
 // Add registers a watch for the given GVR. It blocks until the
 // informer's cache has synced (the initial list is complete). Calling
-// Add for an already-watched GVR is a no-op.
+// Add for an already-watched GVR (including a concurrent Add for the
+// same GVR) blocks until that watch has synced, then returns.
 func (m *Mux) Add(gvr schema.GroupVersionResource) error {
 	m.mu.Lock()
 	if m.stopped {
 		m.mu.Unlock()
 		return ErrStopped
 	}
-	if _, ok := m.watches[gvr]; ok {
+	if existing, ok := m.watches[gvr]; ok {
+		synced := existing.synced
 		m.mu.Unlock()
-		return nil
+		// Honour the "blocks until synced" contract for this caller too,
+		// instead of returning before the first Add finished its initial list.
+		select {
+		case <-synced:
+		case <-m.ctx.Done():
+			return ErrStopped
+		}
+		if m.Has(gvr) {
+			return nil
+		}
+		return fmt.Errorf("concurrent add for %s did not complete", gvr)
 	}
 
 	ctx, cancel := context.WithCancel(m.ctx)
 
-	// Reserve the slot so a concurrent Add for the same GVR is a no-op.
-	m.watches[gvr] = cancel
+	// Reserve the slot so a concurrent Add for the same GVR waits on synced.
+	entry := &watchEntry{cancel: cancel, synced: make(chan struct{})}
+	m.watches[gvr] = entry
 	m.mu.Unlock()
+
+	// Always unblock any waiters, whether this Add succeeds or fails. Waiters
+	// re-check Has() after waking to distinguish success from failure.
+	defer close(entry.synced)
 
 	// Everything below runs without the lock. The informer's event
 	// handlers acquire a read-lock internally, so holding a write-lock
@@ -150,7 +174,10 @@ func (m *Mux) Add(gvr schema.GroupVersionResource) error {
 		return fmt.Errorf("register event handler for %s: %w", gvr, err)
 	}
 
-	go factory.Start(ctx.Done())
+	// Start is non-blocking (it launches the informer goroutines and
+	// returns), so call it directly; wrapping it in `go` would let
+	// WaitForCacheSync run before Start.
+	factory.Start(ctx.Done())
 
 	if !cache.WaitForCacheSync(ctx.Done(), inf.HasSynced) {
 		cancel()
@@ -167,11 +194,11 @@ func (m *Mux) Remove(gvr schema.GroupVersionResource) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	cancel, ok := m.watches[gvr]
+	entry, ok := m.watches[gvr]
 	if !ok {
 		return false
 	}
-	cancel()
+	entry.cancel()
 	delete(m.watches, gvr)
 	return true
 }


### PR DESCRIPTION
A pass over the v2 code from a set of focused reviews. 22 distinct bugs fixed across the store, service, mux, TUI, and diff packages. Everything builds, vets, and passes `go test -race ./...`.

## Concurrency / correctness
- **tracker service TOCTOU (critical):** the lock janitor could evict a per-object lock in the window between lookup and `Lock`, letting two commits mutate the same cached state and fork revisions. Added a validated lock helper, stamp `lastUse` at creation, and guard `objLock` against the nil map after `Close`.
- **cache eviction:** `lastRead` is now stamped before the entry is published, so the janitor can't immediately evict a just-inserted hot entry.
- **Restore:** rejects corrupted patch chains (PreviousID must strictly decrease) instead of looping forever / OOMing.
- **bbolt Close:** idempotent, and joins the periodic-sync goroutine before closing the db (was a close-of-closed-channel panic + a Sync/Close race).
- **mux:** `factory.Start` called directly (the `go` let `WaitForCacheSync` race ahead); `Add` for an in-flight GVR now blocks until that watch has synced.

## TUI
- **timeline reverse:** reversed a copy instead of the shared `entries` slice; double-toggling sort no longer corrupts order.
- **stale revision panel:** the store is copy-on-write, so the revision/detail panels held a stale `*Data` after a new revision arrived for the selected resource. They're now rebound to the fresh copy (with or without auto-scroll).
- **tree cursor snap-back:** the cursor is preserved on its actual item (including kind headers) across live rebuilds instead of jumping back to the selected resource.
- **name truncation:** uses display width, not byte length (multibyte names were dropped).
- guarded `selectCurrent` against a negative cursor.

## cmd
- watches are added asynchronously so a slow or failing informer sync can't freeze the TUI event loop.
- headless mode keeps the collected temp `.loog` file instead of deleting the data on exit.
- stderr restore / devNull close / klog reset moved to `defer`; interrupt channel is `signal.Stop`ped; partial discovery failures are logged.

## diff / analysis
- diffpreview: keyed-list diffs no longer drop scalar additions; empty list/map render as `[]`/`{}` instead of `null`; all integer widths are styled.
- analysis: deterministic loop-period tie-break; loop labels continue past `Z`; guards against non-positive window sizes.
- `CloneMap` deep-clones `[]map[string]any` too.

## Deliberately deferred
- **Diff/Apply null semantics:** `nil` means both "deleted" and "explicit null", so an explicit null value round-trips as a deletion. Fixing it changes the on-disk patch format, so it's not something to slip in the night before a demo. Worth a dedicated PR.
- **Watch-removal informer leak:** removing a watch in the TUI doesn't call `m.Remove` because the callback only gets the kind name, not the GVR. The fix needs a signature change that overlaps open PR #38; better done once that merges.

Regression tests added for the diff, analysis, CloneMap, and bbolt Close fixes.