### PR TITLE
feat: guard --output against existing files and add --replay

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,8 @@ var (
 	filterExpr       string
 	headlessMode     bool
 	simulateMode     bool
+	appendOutput     bool
+	replayFile       string
 )
 
 var rootCmd = &cobra.Command{
@@ -111,6 +113,10 @@ func init() {
 		"Create a full snapshot after this many patches (default 8)")
 	rootCmd.Flags().BoolVar(&simulateMode, "simulate", false,
 		"Run with simulated data instead of connecting to Kubernetes")
+	rootCmd.Flags().BoolVar(&appendOutput, "append", false,
+		"Allow --output to resume an existing .loog file instead of refusing it")
+	rootCmd.Flags().StringVar(&replayFile, "replay", "",
+		"Open an existing .loog file read-only and browse it, without connecting to Kubernetes")
 
 	// allow some flags to be set via environment variables / config file
 	mustBind("kubeconfig",
@@ -157,6 +163,11 @@ func initConfig() {
 // run is the main entry point for the command execution.
 func run(ctx context.Context, args []string) error {
 	setupDebugLogger()
+
+	// Replay mode: open an existing capture read-only and browse it.
+	if replayFile != "" {
+		return runReplayMode()
+	}
 
 	// Simulate mode: skip Kubernetes entirely, use simulated data
 	if simulateMode {
@@ -235,6 +246,56 @@ func runSimulateMode() error {
 	p := tea.NewProgram(app, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		setupLog.Error().Err(err).Msg("Error running TUI program")
+	}
+	return nil
+}
+
+// runReplayMode opens an existing capture read-only and browses it in the TUI.
+// It never connects to Kubernetes and never writes to the file.
+func runReplayMode() error {
+	setupLog.Info().Str("file", replayFile).Msg("Replaying capture (read-only)")
+
+	// Keep klog and stderr off the TUI, same as simulate mode.
+	klog.SetOutput(io.Discard)
+	defer klog.SetOutput(io.Discard)
+	if devNull, derr := os.Open(os.DevNull); derr == nil {
+		savedStderr := os.Stderr
+		os.Stderr = devNull
+		defer func() {
+			os.Stderr = savedStderr
+			_ = devNull.Close()
+		}()
+	}
+
+	rps, err := bboltStore.NewWithOptions(replayFile, bboltStore.Options{ReadOnly: true})
+	if err != nil {
+		return fmt.Errorf("opening replay file: %w", err)
+	}
+	defer func() { _ = rps.Close() }()
+
+	filterProgram, err := expr.Compile(filterExpr, expr.Env(util.EventEntryEnv{}), expr.AsBool())
+	if err != nil {
+		return fmt.Errorf("compiling filter expression: %w", err)
+	}
+
+	liveStore := adapter.NewLiveStore()
+	// A throwaway tracker service (no cache) just satisfies loadHistoryFromDB's
+	// WarmCache call; nothing is committed in replay.
+	trackerService := service.NewTrackerService(rps, snapshotInterval, false)
+	defer func() { _ = trackerService.Close() }()
+
+	// Program is nil: we populate the store up-front, before the TUI runs.
+	handler := &adapter.TUIRevisionHandler{Store: liveStore}
+	if loadErr := loadHistoryFromDB(trackerService, rps, filterProgram, handler); loadErr != nil {
+		return fmt.Errorf("loading capture: %w", loadErr)
+	}
+	liveStore.RebuildKindGroups()
+
+	// No recording, no simulator, no watch callbacks: a pure browse session.
+	app := tui.NewApp(liveStore)
+	p := tea.NewProgram(app, tea.WithAltScreen())
+	if _, runErr := p.Run(); runErr != nil {
+		setupLog.Error().Err(runErr).Msg("Error running TUI program")
 	}
 	return nil
 }
@@ -660,6 +721,19 @@ func loadHistoryFromDB(
 }
 
 func validateArgsAndFlags(_ *cobra.Command, args []string) error {
+	// Replay mode browses an existing file read-only; it can't be combined
+	// with any of the collection/output flags.
+	if replayFile != "" {
+		if len(args) > 0 || outputFile != "" || appendOutput || headlessMode || simulateMode {
+			return fmt.Errorf(
+				"--replay cannot be combined with resource args, --output, --append, --headless, or --simulate")
+		}
+		if info, err := os.Stat(replayFile); err != nil || info.IsDir() {
+			return fmt.Errorf("--replay file %q does not exist or is not a file", replayFile)
+		}
+		return nil
+	}
+
 	// Simulate mode doesn't need resource args or output file
 	if simulateMode {
 		return nil
@@ -668,6 +742,16 @@ func validateArgsAndFlags(_ *cobra.Command, args []string) error {
 	if len(args) == 0 && outputFile == "" {
 		return fmt.Errorf(
 			"at least one resource argument or the --output flag must be provided (you may provide both)")
+	}
+
+	// Guard against silently appending to (and pre-loading) an existing capture.
+	// Resuming is opt-in via --append; browsing read-only is --replay.
+	if outputFile != "" && !appendOutput {
+		if info, err := os.Stat(outputFile); err == nil && !info.IsDir() {
+			return fmt.Errorf(
+				"output file %q already exists; use --append to resume it or --replay to browse it read-only",
+				outputFile)
+		}
 	}
 
 	// validate each provided resource argument

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// resetFlags clears the package-level flag vars that validateArgsAndFlags reads,
+// so each case starts from a known state.
+func resetFlags() {
+	outputFile = ""
+	appendOutput = false
+	replayFile = ""
+	headlessMode = false
+	simulateMode = false
+}
+
+func TestValidateArgsAndFlags(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "capture.loog")
+	if err := os.WriteFile(existing, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(dir, "does-not-exist.loog")
+	fresh := filepath.Join(dir, "new.loog")
+
+	tests := []struct {
+		name    string
+		setup   func()
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "replay existing file",
+			setup:   func() { replayFile = existing },
+			wantErr: false,
+		},
+		{
+			name:    "replay missing file",
+			setup:   func() { replayFile = missing },
+			wantErr: true,
+		},
+		{
+			name:    "replay with output is rejected",
+			setup:   func() { replayFile = existing; outputFile = fresh },
+			wantErr: true,
+		},
+		{
+			name:    "replay with resource args is rejected",
+			setup:   func() { replayFile = existing },
+			args:    []string{"v1/pods"},
+			wantErr: true,
+		},
+		{
+			name:    "output to new file",
+			setup:   func() { outputFile = fresh },
+			wantErr: false,
+		},
+		{
+			name:    "output to existing file without append is rejected",
+			setup:   func() { outputFile = existing },
+			wantErr: true,
+		},
+		{
+			name:    "output to existing file with append",
+			setup:   func() { outputFile = existing; appendOutput = true },
+			wantErr: false,
+		},
+		{
+			name:    "no args and no output is rejected",
+			setup:   func() {},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetFlags()
+			tt.setup()
+			err := validateArgsAndFlags(nil, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateArgsAndFlags() err = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+	resetFlags()
+}

--- a/internal/store/bbolt/readonly_test.go
+++ b/internal/store/bbolt/readonly_test.go
@@ -1,0 +1,58 @@
+package bbolt
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/loog-project/loog/internal/store"
+)
+
+// A read-only store must serve reads from an existing file and reject writes.
+func TestStore_ReadOnly(t *testing.T) {
+	ctx := context.Background()
+	path := t.TempDir() + "/capture.loog"
+
+	// Populate a normal store, then close it.
+	rw, err := New(path, nil, false)
+	if err != nil {
+		t.Fatalf("open rw: %v", err)
+	}
+	snap := &store.Snapshot{
+		PreviousID: 0,
+		Object:     map[string]any{"kind": "ConfigMap", "metadata": map[string]any{"uid": "u1"}},
+		Time:       time.Now(),
+	}
+	if err := rw.SetSnapshot(ctx, "u1", snap); err != nil {
+		t.Fatalf("SetSnapshot: %v", err)
+	}
+	if err := rw.Close(); err != nil {
+		t.Fatalf("close rw: %v", err)
+	}
+
+	// Reopen read-only.
+	ro, err := NewWithOptions(path, Options{ReadOnly: true})
+	if err != nil {
+		t.Fatalf("open ro: %v", err)
+	}
+	defer func() { _ = ro.Close() }()
+
+	// Reads work.
+	count := 0
+	if walkErr := ro.WalkObjectRevisions(func(uid string, _ store.RevisionID, s *store.Snapshot, _ *store.Patch) bool {
+		if uid == "u1" && s != nil {
+			count++
+		}
+		return true
+	}); walkErr != nil {
+		t.Fatalf("walk ro: %v", walkErr)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 snapshot from read-only store, got %d", count)
+	}
+
+	// Writes must fail on a read-only store.
+	if err := ro.SetSnapshot(ctx, "u2", snap); err == nil {
+		t.Error("expected SetSnapshot to fail on a read-only store")
+	}
+}

--- a/internal/store/bbolt/store.go
+++ b/internal/store/bbolt/store.go
@@ -43,6 +43,11 @@ type Options struct {
 	// Compress, when true, applies s2 compression to payloads before storing.
 	// Reduces DB file size at a small CPU cost.
 	Compress bool
+
+	// ReadOnly opens an existing database without allowing writes. Bucket
+	// creation and the periodic sync are skipped. Any write call will fail.
+	// Used for replay/browse of a captured .loog file.
+	ReadOnly bool
 }
 
 type Store struct {
@@ -85,22 +90,27 @@ func NewWithOptions(path string, opts Options) (*Store, error) {
 		Timeout:      0,
 		NoSync:       noSync,
 		NoGrowSync:   noSync,
+		ReadOnly:     opts.ReadOnly,
 		FreelistType: bbolt.FreelistMapType,
 	})
 	if err != nil {
 		return nil, err
 	}
-	err = db.Update(func(tx *bbolt.Tx) error {
-		for _, b := range [][]byte{bucketSnapshots, bucketLatest} {
-			if _, e := tx.CreateBucketIfNotExists(b); e != nil {
-				return e
+	// A read-only db cannot run Update transactions; the buckets already
+	// exist in the file we're opening to browse.
+	if !opts.ReadOnly {
+		err = db.Update(func(tx *bbolt.Tx) error {
+			for _, b := range [][]byte{bucketSnapshots, bucketLatest} {
+				if _, e := tx.CreateBucketIfNotExists(b); e != nil {
+					return e
+				}
 			}
+			return nil
+		})
+		if err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("failed to create default buckets: %w", err)
 		}
-		return nil
-	})
-	if err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("failed to create default buckets: %w", err)
 	}
 
 	s := &Store{


### PR DESCRIPTION
Opening an existing `.loog` with `-o` pre-loads its history and then keeps appending new revisions to the same file. So replaying a capture that way silently mutates it. This adds a guard and a proper read-only browse mode.

## Behavior
- `-o <file>` now refuses to start if the file already exists, with a message pointing at the two escape hatches.
- `--append` opts back into resuming an existing `-o` file.
- `--replay <file>` opens a capture read-only and browses it in the TUI: no Kubernetes connection, no writes, no recording. Mutually exclusive with `-o`, resource args, `--append`, `--headless`, and `--simulate`. Needs no kubeconfig.

## Implementation
- `bbolt.Options` gains `ReadOnly`, which opens the db read-only (skips bucket creation and the sync goroutine; writes fail).
- `runReplayMode` mirrors `runSimulateMode`: opens the store read-only, replays history into a `LiveStore` via the existing `loadHistoryFromDB` path, then runs the TUI as a pure browse session.
- Validation lives in `validateArgsAndFlags`, so bad combinations fail before any store or cluster work.

"Replay" here means open-and-browse, not timed playback.

Tested: flag-combination validation tests, a read-only store test (reads work, writes fail), and manual smoke tests of each path (new `-o` proceeds, existing `-o` refused, `--append` proceeds, `--replay` missing errors). Passes `go test -race ./...`.