### PR TITLE
fix: historic event types, timeline order, and a Changes view mode

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -289,6 +289,7 @@ func runReplayMode() error {
 	if loadErr := loadHistoryFromDB(trackerService, rps, filterProgram, handler); loadErr != nil {
 		return fmt.Errorf("loading capture: %w", loadErr)
 	}
+	liveStore.SortTimeline()
 	liveStore.RebuildKindGroups()
 
 	// No recording, no simulator, no watch callbacks: a pure browse session.
@@ -497,6 +498,10 @@ func runInteractive(
 		if historyErr := loadHistoryFromDB(trackerService, rps, prog, handler); historyErr != nil {
 			log.Error().Err(historyErr).Msg("Error loading history from database")
 		}
+		// History is walked one resource at a time, so the timeline arrives
+		// grouped by resource. Sort it chronologically and refresh once.
+		liveStore.SortTimeline()
+		program.Send(adapter.LiveRevisionMsg{})
 	}()
 	go func() {
 		defer wg.Done()
@@ -728,7 +733,11 @@ func loadHistoryFromDB(
 			return true
 		}
 
-		if handleErr := handler.HandleRevision(unstructuredObj, revisionID, current, patch); handleErr != nil {
+		// Pass the original snapshot/patch (not the reconstructed `current`) so
+		// the handler derives the correct event type and PreviousID. `current`
+		// always has PreviousID 0, which made every historic revision look ADDED.
+		// The full reconstructed object travels in unstructuredObj.
+		if handleErr := handler.HandleRevision(unstructuredObj, revisionID, snapshot, patch); handleErr != nil {
 			log.Error().Err(handleErr).Msg("Error handling historic revision")
 		}
 		return true

--- a/internal/adapter/history_test.go
+++ b/internal/adapter/history_test.go
@@ -1,0 +1,82 @@
+package adapter
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/loog-project/loog/internal/resource"
+	"github.com/loog-project/loog/internal/store"
+)
+
+// SortTimeline should order a timeline that was ingested grouped-by-resource
+// (as bulk history load does) into a globally chronological, newest-first list.
+func TestLiveStore_SortTimeline(t *testing.T) {
+	s := NewLiveStore()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Ingest resource A's revisions, then resource B's, out of global time order.
+	s.IngestRevision("a", "Pod", "a", "default", resource.Revision{ID: 1, Time: base.Add(1 * time.Minute)})
+	s.IngestRevision("a", "Pod", "a", "default", resource.Revision{ID: 2, Time: base.Add(3 * time.Minute)})
+	s.IngestRevision("b", "Pod", "b", "default", resource.Revision{ID: 3, Time: base.Add(2 * time.Minute)})
+	s.IngestRevision("b", "Pod", "b", "default", resource.Revision{ID: 4, Time: base.Add(4 * time.Minute)})
+
+	s.SortTimeline()
+
+	tl := s.Timeline()
+	if len(tl) != 4 {
+		t.Fatalf("expected 4 timeline entries, got %d", len(tl))
+	}
+	for i := 1; i < len(tl); i++ {
+		if tl[i-1].Revision.Time.Before(tl[i].Revision.Time) {
+			t.Errorf("timeline not newest-first at %d: %v before %v",
+				i, tl[i-1].Revision.Time, tl[i].Revision.Time)
+		}
+	}
+	// Newest first means the +4m revision leads.
+	if !tl[0].Revision.Time.Equal(base.Add(4 * time.Minute)) {
+		t.Errorf("expected newest (+4m) first, got %v", tl[0].Revision.Time)
+	}
+}
+
+// A revision built from a patch (no snapshot) must be MODIFIED, not ADDED.
+// This mirrors the history-load path, which previously mislabeled everything.
+func TestBuildRevision_PatchIsModified(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"kind":     "Pod",
+		"metadata": map[string]any{"uid": "u1", "name": "p"},
+	}}
+	patch := &store.Patch{PreviousID: 5, Time: time.Now(), Patch: map[string]any{"spec": map[string]any{"x": 1}}}
+
+	rev := buildRevision(obj, 6, nil, patch)
+	if rev.EventType != resource.EventModified {
+		t.Errorf("patch revision event = %v, want MODIFIED", rev.EventType)
+	}
+	if rev.PreviousID != resource.RevisionID(5) {
+		t.Errorf("patch revision PreviousID = %d, want 5", rev.PreviousID)
+	}
+	if rev.Patch == nil {
+		t.Error("patch revision should carry the patch diff")
+	}
+}
+
+// A snapshot revision with a non-zero PreviousID is a MODIFIED, not ADDED.
+func TestBuildRevision_LaterSnapshotIsModified(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{"kind": "Pod"}}
+	snap := &store.Snapshot{PreviousID: 8, Time: time.Now()}
+	rev := buildRevision(obj, 16, snap, nil)
+	if rev.EventType != resource.EventModified {
+		t.Errorf("later snapshot event = %v, want MODIFIED", rev.EventType)
+	}
+}
+
+// The very first snapshot (PreviousID 0) is ADDED.
+func TestBuildRevision_FirstSnapshotIsAdded(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{"kind": "Pod"}}
+	snap := &store.Snapshot{PreviousID: 0, Time: time.Now()}
+	rev := buildRevision(obj, 1, snap, nil)
+	if rev.EventType != resource.EventAdded {
+		t.Errorf("first snapshot event = %v, want ADDED", rev.EventType)
+	}
+}

--- a/internal/adapter/livestore.go
+++ b/internal/adapter/livestore.go
@@ -331,6 +331,19 @@ func (s *LiveStore) RebuildKindGroups() {
 	s.kindGroups = resource.BuildKindGroups(all)
 }
 
+// SortTimeline orders the timeline newest-first by revision time. IngestRevision
+// keeps the timeline in arrival order, which is correct for live events but not
+// for a bulk history load that walks one resource's revisions at a time. Call
+// this once after loading history so the timeline is globally chronological.
+func (s *LiveStore) SortTimeline() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	slices.SortStableFunc(s.timeline, func(a, b resource.TimelineEntry) int {
+		// Newest first.
+		return b.Revision.Time.Compare(a.Revision.Time)
+	})
+}
+
 func (s *LiveStore) ForEachResource(fn func(uid string, rd *resource.Data)) {
 	// Snapshot under the lock, then invoke the callback outside it. This keeps
 	// the write lock off the collector's ingestion path while the callback does

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -67,7 +67,7 @@ func NewCommandRegistry() *CommandRegistry {
 		Action: func() tea.Cmd { return Cmd(ViewModeChangedMsg{Mode: ObjectMode}) },
 	})
 	cr.Register(Command{
-		Name: "View: Patch Mode", Description: "Show only changed fields", Shortcut: "p",
+		Name: "View: Changes Mode", Description: "Show only fields changed vs the previous revision", Shortcut: "p",
 		Action: func() tea.Cmd { return Cmd(ViewModeChangedMsg{Mode: PatchMode}) },
 	})
 	cr.Register(Command{

--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -1230,7 +1230,7 @@ func (dv *DetailView) CurrentHint() string {
 	return strings.Join([]string{
 		dv.theme.KeyHint("d", "diff"),
 		dv.theme.KeyHint("o", "object"),
-		dv.theme.KeyHint("p", "patch"),
+		dv.theme.KeyHint("p", "changes"),
 		dv.theme.KeyHint("J", "json"),
 		dv.theme.KeyHint("r", "raw"),
 		dv.theme.KeyHint("[/]", "prev/next"),
@@ -1271,12 +1271,7 @@ func (dv *DetailView) renderContent() {
 	case ObjectMode:
 		body = RenderYAMLObject(rev.Object, dv.theme, 2)
 	case PatchMode:
-		if rev.Patch != nil {
-			body = RenderYAMLObject(rev.Patch, dv.theme, 2)
-		} else {
-			body = lipgloss.NewStyle().Foreground(dv.theme.Overlay0).Italic(true).
-				Render("(no patch - this is a full snapshot)")
-		}
+		body = dv.renderChanges(rev)
 	case JSONMode:
 		body = RenderJSONObject(rev.Object, dv.theme)
 	case RawMode:
@@ -1309,6 +1304,31 @@ func (dv *DetailView) renderDiff(rev resource.Revision) string {
 		IndentSize:                2,
 		EnableBackgroundHighlight: true,
 	})
+}
+
+// renderChanges shows only the fields that changed versus the previous
+// revision, computed from the objects. Unlike the stored patch, this works for
+// snapshot revisions too (they have no stored patch).
+func (dv *DetailView) renderChanges(rev resource.Revision) string {
+	if rev.Object == nil {
+		return dv.theme.MutedStyle().Render("(no object data)")
+	}
+
+	var prevObj map[string]any
+	if dv.revIndex > 0 {
+		prevObj = dv.resource.Revisions[dv.revIndex-1].Object
+	}
+
+	node := diffpreview.Diff(prevObj, rev.Object)
+	out := diffpreview.RenderYAML(node, dv.theme.DiffPreviewTheme(), diffpreview.RenderOptions{
+		IndentSize:                2,
+		EnableBackgroundHighlight: true,
+		ChangesOnly:               true,
+	})
+	if strings.TrimSpace(out) == "" {
+		return dv.theme.MutedStyle().Render("(no changes from previous revision)")
+	}
+	return out
 }
 
 // renderRaw shows the revision as a raw database record.

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -156,7 +156,7 @@ func (h *HelpOverlay) View() string {
 		{Title: "Detail View", Bindings: []helpBinding{
 			{"d", "Diff mode (YAML with highlighting)"},
 			{"o", "Object mode (full YAML)"},
-			{"p", "Patch mode (changes only)"},
+			{"p", "Changes mode (only fields changed vs previous)"},
 			{"J", "JSON mode"},
 			{"r", "Raw mode (database record)"},
 			{"[ / ]", "Previous / next revision"},

--- a/internal/tui/types.go
+++ b/internal/tui/types.go
@@ -40,7 +40,7 @@ type ViewMode int
 const (
 	DiffMode   ViewMode = iota // Full object YAML with diff highlighting
 	ObjectMode                 // Full YAML, no diff annotations
-	PatchMode                  // Only changed fields
+	PatchMode                  // Only the fields that changed vs the previous revision
 	JSONMode                   // Raw JSON
 	RawMode                    // Raw database representation (debug)
 )
@@ -52,7 +52,7 @@ func (m ViewMode) String() string {
 	case ObjectMode:
 		return "Object"
 	case PatchMode:
-		return "Patch"
+		return "Changes"
 	case JSONMode:
 		return "JSON"
 	case RawMode:

--- a/pkg/diffpreview/changesonly_test.go
+++ b/pkg/diffpreview/changesonly_test.go
@@ -1,0 +1,44 @@
+package diffpreview
+
+import (
+	"strings"
+	"testing"
+)
+
+// ChangesOnly should keep changed paths and drop unchanged siblings.
+func TestRender_ChangesOnly(t *testing.T) {
+	a := map[string]any{
+		"metadata": map[string]any{"name": "p", "resourceVersion": "1"},
+		"spec":     map[string]any{"replicas": float64(1), "image": "nginx:1"},
+		"status":   map[string]any{"phase": "Running"},
+	}
+	b := map[string]any{
+		"metadata": map[string]any{"name": "p", "resourceVersion": "2"},
+		"spec":     map[string]any{"replicas": float64(3), "image": "nginx:1"},
+		"status":   map[string]any{"phase": "Running"},
+	}
+	node := Diff(a, b)
+	out := RenderYAML(node, plainTheme, RenderOptions{IndentSize: 2, ChangesOnly: true})
+
+	assertContains(t, out, "resourceVersion")
+	assertContains(t, out, "replicas")
+	if strings.Contains(out, "phase") {
+		t.Errorf("ChangesOnly should drop unchanged 'status.phase':\n%s", out)
+	}
+	if strings.Contains(out, "image") {
+		t.Errorf("ChangesOnly should drop unchanged 'spec.image':\n%s", out)
+	}
+	if strings.Contains(out, `name: "p"`) {
+		t.Errorf("ChangesOnly should drop unchanged 'metadata.name':\n%s", out)
+	}
+}
+
+// ChangesOnly on identical objects yields no output.
+func TestRender_ChangesOnlyEmptyWhenEqual(t *testing.T) {
+	m := map[string]any{"spec": map[string]any{"replicas": float64(1)}}
+	node := Diff(m, m)
+	out := RenderYAML(node, plainTheme, RenderOptions{IndentSize: 2, ChangesOnly: true})
+	if strings.TrimSpace(out) != "" {
+		t.Errorf("expected empty output for equal objects, got:\n%q", out)
+	}
+}

--- a/pkg/diffpreview/renderer.go
+++ b/pkg/diffpreview/renderer.go
@@ -9,6 +9,10 @@ import (
 type RenderOptions struct {
 	IndentSize                int
 	EnableBackgroundHighlight bool
+	// ChangesOnly, when true, omits map keys and list items that have no
+	// changes anywhere in their subtree, producing a compact diff that shows
+	// only what changed (with the surrounding path kept for context).
+	ChangesOnly bool
 }
 
 // RenderYAML turns an AnnotatedNode tree into syntax-highlighted YAML with
@@ -45,6 +49,9 @@ func (r *renderer) renderMap(children map[string]*AnnotatedNode, level int) {
 	prefix := r.indent(level)
 	for _, key := range sortedKeys(children) {
 		child := children[key]
+		if r.opts.ChangesOnly && !hasChanges(child) {
+			continue
+		}
 		r.sb.WriteString(prefix + r.styledKey(key, child.Change))
 		r.renderChildValue(child, level)
 	}
@@ -56,6 +63,9 @@ func (r *renderer) renderList(items []*AnnotatedNode, level int, parentChange Ch
 	prefix := r.indent(level)
 
 	for _, item := range items {
+		if r.opts.ChangesOnly && !hasChanges(item) {
+			continue
+		}
 		change := effectiveChange(item.Change, parentChange)
 		dash := r.styledDash(change)
 
@@ -80,6 +90,15 @@ func (r *renderer) renderList(items []*AnnotatedNode, level int, parentChange Ch
 // "- " line; the rest are indented one level deeper.
 func (r *renderer) renderListMapItem(children map[string]*AnnotatedNode, prefix, dash string, level int, _ ChangeType) {
 	keys := sortedKeys(children)
+	if r.opts.ChangesOnly {
+		filtered := keys[:0:0]
+		for _, k := range keys {
+			if hasChanges(children[k]) {
+				filtered = append(filtered, k)
+			}
+		}
+		keys = filtered
+	}
 	if len(keys) == 0 {
 		r.sb.WriteString(prefix + dash + "{}\n")
 		return


### PR DESCRIPTION
Three issues found while testing replay. All three affect historic/replayed data.

## (a) Everything showed as ADDED
loadHistoryFromDB passed a reconstructed snapshot (PreviousID 0) to the handler, so buildRevision always took the first-snapshot -> ADDED branch. Now it passes the original snapshot/patch from the walk (nil snapshot for patch revisions); the full reconstructed object still travels in the unstructured object. Event types are correct now: ADDED for the first revision, MODIFIED otherwise.

## (b) Timeline grouped by resource instead of chronological
WalkObjectRevisions yields one resource's whole history at a time and IngestRevision keeps arrival order, so a bulk load grouped the timeline by resource (screenshot: all DatabaseInstance, then all ServiceInstance). Added LiveStore.SortTimeline(), called once after loading (replay, and the interactive history goroutine + a refresh). Live events keep prepending newest-first.

## (c) Patch view -> Changes view
Patch mode only rendered the stored patch, which is empty for snapshot revisions. Replaced it with a Changes view that computes the actual diff vs the previous revision (works for snapshots too), rendered compactly via a new ChangesOnly option on diffpreview.RenderOptions that prunes unchanged subtrees. Same p shortcut; relabeled in the detail hint, command palette, and help.

Tests added for ChangesOnly rendering, SortTimeline ordering, and the event type buildRevision derives. Passes go test -race ./....

Different fix than the slices.Reverse aliasing in #39 (that was the sort toggle corrupting the slice); this is the initial global ordering after a bulk load.