### PR TITLE
fix(tui): re-focus the primary pane when switching views

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -753,6 +753,11 @@ func (a *App) switchView(v ViewID) {
 	a.debugLog.Debug("app", "switch view: %s → %s", a.activeView, v)
 	a.activeView = v
 	a.header.SetView(v)
+	// Re-assert focus on the view's primary (left) panel. Panel focus is stored
+	// per view and persists across switches, so without this a view entered
+	// with the detail pane focused (from a previous visit) would silently
+	// swallow list keys like R, j, and k until the user pressed Tab.
+	a.focusPanel(PanelLeft)
 }
 
 func (a *App) nextPanel() {

--- a/internal/tui/switchview_focus_test.go
+++ b/internal/tui/switchview_focus_test.go
@@ -1,0 +1,53 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Switching to a view must focus its primary (left) pane, so list keys work
+// immediately. Regression: focus state persisted across view switches, so
+// returning to the timeline with the detail pane previously focused made R
+// and navigation silently no-op.
+func TestSwitchView_FocusesLeftPane(t *testing.T) {
+	store := newDataStore()
+	app := NewApp(store)
+	m, _ := app.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	app = m.(*App)
+
+	pressR := func() {
+		m, _ := app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'R'}})
+		app = m.(*App)
+	}
+
+	app.switchView(TimelineView)
+	if !app.timeline.timeline.focused {
+		t.Fatal("timeline list should be focused after switching to the timeline view")
+	}
+
+	// R works from the resources (left) pane.
+	pressR()
+	if !app.timeline.timeline.Reversed() {
+		t.Fatal("R should toggle reverse when the timeline pane is focused")
+	}
+
+	// Tab to the detail pane, then leave and return to the timeline view.
+	m, _ = app.Update(tea.KeyMsg{Type: tea.KeyTab})
+	app = m.(*App)
+	if app.timeline.timeline.focused {
+		t.Fatal("timeline list should not be focused after tabbing to detail")
+	}
+	app.switchView(ExplorerView)
+	app.switchView(TimelineView)
+
+	// Focus must be back on the list pane so R works again without a manual Tab.
+	if !app.timeline.timeline.focused {
+		t.Fatal("returning to the timeline view should re-focus the list pane")
+	}
+	wasReversed := app.timeline.timeline.Reversed()
+	pressR()
+	if app.timeline.timeline.Reversed() == wasReversed {
+		t.Fatal("R should toggle reverse after returning to the timeline view")
+	}
+}


### PR DESCRIPTION
## What you hit
R (reverse) felt flakey: sometimes several presses did nothing, then it toggled.

## Root cause
The reverse mechanics are fine. The problem is panel focus. Focus is stored per view and persists across view switches, and switchView never re-asserted it. So this sequence leaves the timeline's list pane unfocused:

1. In the Timeline view, Tab to the detail (right) pane.
2. Switch to another view and back.
3. The timeline view shows again, but focusPanel is still the detail pane.

While the list pane is unfocused, TimelineList.Update returns early (if !tl.focused), so R (and j/k navigation) are silently dropped until you press Tab. I confirmed this with a scratch harness: after switch-away-and-back, timeline.focused == false.

## Fix
switchView now focuses the view's primary (left) pane on entry, so the resources/list pane is always focused when you enter a view and list keys work immediately. Reverse stays a resources-pane action, no change to that.

Regression test included; it fails without the fix and passes with it. go test -race ./... is green.