### PR TITLE
fix(store): auto-detect payload compression (fixes --replay decode error)

### DIFF
--- a/internal/store/bbolt/compression_test.go
+++ b/internal/store/bbolt/compression_test.go
@@ -1,0 +1,74 @@
+package bbolt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/loog-project/loog/internal/store"
+)
+
+// A store written with compression must be readable even when reopened without
+// the Compress flag set (this is what --replay does: it can't know the original
+// setting). Previously this produced "msgpack: unexpected code=... decoding map
+// length" because the reader fed S2 bytes straight to the decoder.
+func TestStore_CompressionAutodetect(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name       string
+		writeCompr bool
+	}{
+		{"written compressed", true},
+		{"written uncompressed", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := t.TempDir() + "/capture.loog"
+
+			w, err := NewWithOptions(path, Options{Compress: tc.writeCompr})
+			if err != nil {
+				t.Fatalf("open write: %v", err)
+			}
+			snap := &store.Snapshot{
+				Object: map[string]any{
+					"kind":     "ConfigMap",
+					"metadata": map[string]any{"uid": "u1", "name": "example-name"},
+					"data":     map[string]any{"key": "some-value-to-compress"},
+				},
+			}
+			if err := w.SetSnapshot(ctx, "u1", snap); err != nil {
+				t.Fatalf("SetSnapshot: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("close write: %v", err)
+			}
+
+			// Reopen with the OPPOSITE compress flag, as replay (Compress:false)
+			// would for a compressed file. Auto-detection must make reads work.
+			r, err := NewWithOptions(path, Options{Compress: !tc.writeCompr, ReadOnly: true})
+			if err != nil {
+				t.Fatalf("open read: %v", err)
+			}
+			defer func() { _ = r.Close() }()
+
+			var got *store.Snapshot
+			err = r.WalkObjectRevisions(func(_ string, _ store.RevisionID, s *store.Snapshot, _ *store.Patch) bool {
+				if s != nil {
+					got = s
+				}
+				return true
+			})
+			if err != nil {
+				t.Fatalf("walk: %v", err)
+			}
+			if got == nil {
+				t.Fatal("no snapshot read back")
+			}
+			meta, _ := got.Object["metadata"].(map[string]any)
+			if meta == nil || meta["name"] != "example-name" {
+				t.Errorf("round-trip mismatch: %#v", got.Object)
+			}
+		})
+	}
+}

--- a/internal/store/bbolt/helpers.go
+++ b/internal/store/bbolt/helpers.go
@@ -108,6 +108,50 @@ func decompressPayload(compressed []byte) ([]byte, error) {
 	return s2.Decode(nil, compressed)
 }
 
+// detectCompression inspects the first stored record and aligns s.compress with
+// how the file was actually written. Compression is not recorded per record, so
+// a store opened with the wrong setting (e.g. --replay, which can't know the
+// original flag) would otherwise feed compressed bytes straight to the decoder.
+func (s *Store) detectCompression() {
+	_ = s.db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(bucketSnapshots)
+		if b == nil {
+			return nil
+		}
+		k, v := b.Cursor().First()
+		if k == nil || len(v) < 1 {
+			return nil
+		}
+		payload := v[1:]
+		// An uncompressed record unmarshals directly; try that first so raw
+		// msgpack is never mistaken for a compressed block.
+		if s.recordUnmarshals(v[0], payload) {
+			s.compress = false
+			return nil
+		}
+		// Otherwise, if it decompresses and then unmarshals, it was compressed.
+		if d, err := decompressPayload(payload); err == nil && s.recordUnmarshals(v[0], d) {
+			s.compress = true
+		}
+		return nil
+	})
+}
+
+// recordUnmarshals reports whether payload decodes into the record type named
+// by typeByte. Used only for compression probing at open time.
+func (s *Store) recordUnmarshals(typeByte byte, payload []byte) bool {
+	switch typeByte {
+	case typePatch:
+		var p store.Patch
+		return s.codec.Unmarshal(payload, &p) == nil
+	case typeSnapshot:
+		var sn store.Snapshot
+		return s.codec.Unmarshal(payload, &sn) == nil
+	default:
+		return false
+	}
+}
+
 func (s *Store) parsePatchOrSnapshot(v []byte) (*store.Snapshot, *store.Patch, error) {
 	if len(v) < 1 {
 		return nil, nil, store.ErrInvalidRevision

--- a/internal/store/bbolt/store.go
+++ b/internal/store/bbolt/store.go
@@ -122,6 +122,12 @@ func NewWithOptions(path string, opts Options) (*Store, error) {
 		compress:            opts.Compress,
 	}
 
+	// Compression is not recorded per record, so a store must read with the
+	// same setting the file was written with. Callers that open an existing
+	// file may not know that setting (notably --replay, which can't), so align
+	// s.compress with what's actually on disk by probing the first record.
+	s.detectCompression()
+
 	// Start periodic sync goroutine if configured.
 	if opts.Durable && opts.SyncInterval > 0 {
 		s.stopSync = make(chan struct{})


### PR DESCRIPTION
## What you hit
`--replay <file>.loog` always failed with:
> Error: loading capture: msgpack: unexpected code=a5 decoding map length

## Root cause
Compression is a store-level option that is **not** recorded per record. The reader only decompresses when its own `Compress` flag is set (`parsePatchOrSnapshot`). Captures are written **compressed by default**, but `--replay` opens the store read-only with `Compress` defaulting to `false`. So it stripped the type byte and handed the still-S2-compressed bytes straight to msgpack, which choked on the first byte of the compressed block (`a5`).

## Fix
Probe the first stored record at open time and align `s.compress` with what's actually on disk: try decoding the record raw first (uncompressed), then via S2. This makes a file open correctly regardless of the `Compress` flag the caller passed, which is exactly what `--replay` needs since it can't know the original setting. It also makes `--append` robust to a flag mismatch.

The hot read path is unchanged; detection is a single record probe at open.

## Tests
Added a round-trip test that writes with one setting and reopens with the opposite (both directions). It reproduces the reported error without the fix (`unexpected code=... decoding map length` for compressed, `s2: corrupt input` for uncompressed) and passes with it. `go test -race ./...` green.