### PR TITLE
feat(timeline): order near-simultaneous events by resourceVersion

### DIFF
--- a/internal/adapter/handler.go
+++ b/internal/adapter/handler.go
@@ -2,12 +2,14 @@ package adapter
 
 import (
 	"fmt"
+	"strconv"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/loog-project/loog/internal/resource"
 	"github.com/loog-project/loog/internal/store"
+	"github.com/loog-project/loog/internal/util"
 )
 
 // LiveRevisionMsg tells the TUI that a new revision has been ingested into the LiveStore.
@@ -70,6 +72,13 @@ func buildRevision(
 	rev := resource.Revision{
 		ID:     revID,
 		Object: resource.CloneMap(obj.Object),
+	}
+
+	// Capture resourceVersion for causal ordering in the timeline.
+	if rvStr, ok := util.ExtractResourceVersion(obj.Object); ok {
+		if rv, err := strconv.ParseUint(rvStr, 10, 64); err == nil {
+			rev.ResourceVersion = rv
+		}
 	}
 
 	if snapshot != nil {

--- a/internal/adapter/livestore.go
+++ b/internal/adapter/livestore.go
@@ -143,6 +143,7 @@ func (s *LiveStore) FilterTimeline(expr string, starredOnly bool) []resource.Tim
 	if expr == "" && !starredOnly {
 		result := make([]resource.TimelineEntry, len(s.timeline))
 		copy(result, s.timeline)
+		resource.SortTimelineNewestFirst(result)
 		return result
 	}
 
@@ -160,6 +161,7 @@ func (s *LiveStore) FilterTimeline(expr string, starredOnly bool) []resource.Tim
 		}
 		result = append(result, e)
 	}
+	resource.SortTimelineNewestFirst(result)
 	return result
 }
 
@@ -169,6 +171,7 @@ func (s *LiveStore) Timeline() []resource.TimelineEntry {
 
 	result := make([]resource.TimelineEntry, len(s.timeline))
 	copy(result, s.timeline)
+	resource.SortTimelineNewestFirst(result)
 	return result
 }
 
@@ -339,8 +342,7 @@ func (s *LiveStore) SortTimeline() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	slices.SortStableFunc(s.timeline, func(a, b resource.TimelineEntry) int {
-		// Newest first.
-		return b.Revision.Time.Compare(a.Revision.Time)
+		return resource.CompareRevisionsNewestFirst(a.Revision, b.Revision)
 	})
 }
 

--- a/internal/adapter/resourceversion_test.go
+++ b/internal/adapter/resourceversion_test.go
@@ -1,0 +1,37 @@
+package adapter
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/loog-project/loog/internal/store"
+)
+
+// buildRevision must capture metadata.resourceVersion as a parsed uint64 so the
+// timeline can order near-simultaneous events causally.
+func TestBuildRevision_CapturesResourceVersion(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"kind": "ConfigMap",
+		"metadata": map[string]any{
+			"uid":             "u1",
+			"name":            "cm",
+			"resourceVersion": "123456",
+		},
+	}}
+	rev := buildRevision(obj, 1, &store.Snapshot{PreviousID: 0}, nil)
+	if rev.ResourceVersion != 123456 {
+		t.Errorf("ResourceVersion = %d, want 123456", rev.ResourceVersion)
+	}
+}
+
+func TestBuildRevision_MissingResourceVersionIsZero(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"kind":     "ConfigMap",
+		"metadata": map[string]any{"uid": "u1", "name": "cm"},
+	}}
+	rev := buildRevision(obj, 1, &store.Snapshot{PreviousID: 0}, nil)
+	if rev.ResourceVersion != 0 {
+		t.Errorf("ResourceVersion = %d, want 0 when absent", rev.ResourceVersion)
+	}
+}

--- a/internal/resource/helpers.go
+++ b/internal/resource/helpers.go
@@ -91,6 +91,36 @@ func GroupTimelineByBurst(entries []TimelineEntry, window time.Duration) []any {
 	return result
 }
 
+// NearSimultaneousWindow is the wall-clock gap below which two adjacent
+// revisions are treated as near-simultaneous: their relative order is inferred
+// (from resourceVersion, or arrival) rather than clearly separated in time.
+const NearSimultaneousWindow = time.Second
+
+// CompareRevisionsNewestFirst orders two revisions newest-first. It prefers
+// resourceVersion (a global, causal order on etcd-backed clusters) when both
+// revisions carry one, and falls back to wall-clock time otherwise. Returns a
+// value suitable for sort funcs (<0 if a should sort before b).
+func CompareRevisionsNewestFirst(a, b Revision) int {
+	if a.ResourceVersion != 0 && b.ResourceVersion != 0 && a.ResourceVersion != b.ResourceVersion {
+		// Higher resourceVersion = later change = newer -> sorts first.
+		if a.ResourceVersion > b.ResourceVersion {
+			return -1
+		}
+		return 1
+	}
+	// Fall back to time (later = newer -> sorts first).
+	return b.Time.Compare(a.Time)
+}
+
+// SortTimelineNewestFirst sorts timeline entries in place, newest-first, using
+// causal order where resourceVersion is available (see
+// CompareRevisionsNewestFirst).
+func SortTimelineNewestFirst(entries []TimelineEntry) {
+	sort.SliceStable(entries, func(i, j int) bool {
+		return CompareRevisionsNewestFirst(entries[i].Revision, entries[j].Revision) < 0
+	})
+}
+
 // CloneMap performs a recursive clone of a map[string]any.
 // It recursively clones nested maps and slices, but shares scalar values
 // (which are immutable in Go). Non-JSON collection shapes other than

--- a/internal/resource/ordering_test.go
+++ b/internal/resource/ordering_test.go
@@ -1,0 +1,56 @@
+package resource
+
+import (
+	"testing"
+	"time"
+)
+
+// resourceVersion must decide order for near-simultaneous events, even when the
+// wall-clock times are inverted (as they can be across independent watches).
+func TestCompareRevisionsNewestFirst_ResourceVersionWins(t *testing.T) {
+	base := time.Now()
+	// A happened first (lower rv) but was OBSERVED later (later time).
+	a := Revision{ResourceVersion: 100, Time: base.Add(50 * time.Millisecond)}
+	// B happened second (higher rv) but was observed first (earlier time).
+	b := Revision{ResourceVersion: 105, Time: base}
+
+	// Newest-first: B (higher rv) must sort before A despite its earlier time.
+	if got := CompareRevisionsNewestFirst(b, a); got >= 0 {
+		t.Errorf("expected B (rv 105) before A (rv 100), got %d", got)
+	}
+	if got := CompareRevisionsNewestFirst(a, b); got <= 0 {
+		t.Errorf("expected A after B, got %d", got)
+	}
+}
+
+func TestCompareRevisionsNewestFirst_FallsBackToTime(t *testing.T) {
+	base := time.Now()
+	// No resourceVersion -> order by time, newest first.
+	newer := Revision{Time: base.Add(time.Second)}
+	older := Revision{Time: base}
+	if got := CompareRevisionsNewestFirst(newer, older); got >= 0 {
+		t.Errorf("expected newer before older by time, got %d", got)
+	}
+	// One side missing rv -> also falls back to time.
+	mixed := Revision{ResourceVersion: 7, Time: base}
+	if got := CompareRevisionsNewestFirst(mixed, newer); got <= 0 {
+		t.Errorf("expected time fallback to put newer first, got %d", got)
+	}
+}
+
+func TestSortTimelineNewestFirst_CausalOrder(t *testing.T) {
+	base := time.Now()
+	// Simulate the reported scenario: B observed before A, but A is causally
+	// first (lower rv). Ready events land within the same instant.
+	entries := []TimelineEntry{
+		{Revision: Revision{ResourceVersion: 205, Time: base}},                       // B ready (observed first)
+		{Revision: Revision{ResourceVersion: 200, Time: base.Add(30 * time.Millisecond)}}, // A ready (observed later)
+	}
+	SortTimelineNewestFirst(entries)
+
+	// Newest-first: B (rv 205, causally later) must be first, A second.
+	if entries[0].Revision.ResourceVersion != 205 || entries[1].Revision.ResourceVersion != 200 {
+		t.Errorf("causal order wrong: got %d then %d",
+			entries[0].Revision.ResourceVersion, entries[1].Revision.ResourceVersion)
+	}
+}

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -71,6 +71,13 @@ type Revision struct {
 	Time       time.Time
 	Object     map[string]any // full state at this revision
 	Patch      map[string]any // diff from previous (nil for ADD/snapshots)
+	// ResourceVersion is the Kubernetes metadata.resourceVersion parsed as a
+	// uint64, or 0 if absent/unparseable. On etcd-backed clusters it is a
+	// global, monotonically increasing revision, so it orders changes across
+	// different resources by true causal order - unlike Time, which is only
+	// loog's observation time and can invert for near-simultaneous events on
+	// separate watch streams.
+	ResourceVersion uint64
 }
 
 // TimelineEntry represents a single entry in the unified timeline.

--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -1512,6 +1512,10 @@ type timelineFlatItem struct {
 	isBurstEnd   bool
 	isBurstMid   bool
 	burstSize    int
+	// approxOrder is true when this entry is within NearSimultaneousWindow of
+	// the adjacent entry, so its position relative to that neighbor is inferred
+	// (by resourceVersion or arrival) rather than clearly separated in time.
+	approxOrder bool
 }
 
 func NewTimelineList(theme Theme) *TimelineList {
@@ -1768,6 +1772,25 @@ func (tl *TimelineList) buildFlatItems() {
 			}
 		}
 	}
+
+	// Flag entries whose order relative to an adjacent entry is inferred
+	// because they fall within the near-simultaneous window. Ordering across
+	// resources for events this close is decided by resourceVersion (or
+	// arrival), not by clearly separated wall-clock times.
+	for i := 1; i < len(tl.flatItems); i++ {
+		a, b := tl.flatItems[i-1].entry, tl.flatItems[i].entry
+		if a == nil || b == nil {
+			continue
+		}
+		gap := a.Revision.Time.Sub(b.Revision.Time)
+		if gap < 0 {
+			gap = -gap
+		}
+		if gap < resource.NearSimultaneousWindow {
+			tl.flatItems[i-1].approxOrder = true
+			tl.flatItems[i].approxOrder = true
+		}
+	}
 }
 
 // CurrentHint returns a context-sensitive hint for the status bar.
@@ -2019,7 +2042,14 @@ func (tl *TimelineList) View() string {
 			}
 		}
 
-		line := burstPrefix + anchorMark + timeStr + " " + compareBadge + star + kindName + " " + etStr
+		// Marker for near-simultaneous entries whose order is inferred (by
+		// resourceVersion or arrival) rather than clearly separated in time.
+		approxMark := ""
+		if item.approxOrder && !isDimmed {
+			approxMark = " " + lipgloss.NewStyle().Foreground(tl.theme.Overlay0).Render("≈")
+		}
+
+		line := burstPrefix + anchorMark + timeStr + " " + compareBadge + star + kindName + " " + etStr + approxMark
 
 		padded := PadRight(line, tl.width)
 		if isSelected {

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -145,6 +145,7 @@ func (h *HelpOverlay) View() string {
 			{"S", "Toggle starred-only filter"},
 			{"R", "Reverse sort direction"},
 			{"w", "Cycle time window around selected"},
+			{"≈", "Order inferred (events <1s apart; sorted by resourceVersion)"},
 		}},
 		{Title: "Compare View", Bindings: []helpBinding{
 			{"Tab", "Switch left / right pane"},


### PR DESCRIPTION
## The problem you described
Operator A reconciles resource A; operator B watches A and writes B's status only after A becomes ready. In the timeline, B sometimes appeared to become ready *before* A, which is causally impossible. In the raw data, B's revision had an earlier timestamp than A's.

## Root cause
A revision's `Time` is `time.Now()` at the moment loog *commits* the watch event (tracker_service `newPatch`/`newSnapshot`), i.e. loog's observation time, not when the change happened in the cluster. The timeline sorts by that time. A and B are watched by independent informers with separate watch streams and no cross-stream ordering guarantee, so for changes within a short window loog can observe B before A and stamp it earlier. It's not a sort bug; the stored timestamps are in observation order, which isn't causal.

## Fix (option 1 + a visual cue)
- Capture `metadata.resourceVersion` on each revision (parsed to uint64) in `buildRevision`, so it's set for both live and replayed data.
- Sort the timeline newest-first by `resourceVersion` when both revisions have one, falling back to `Time` otherwise. On etcd-backed clusters resourceVersion is a global, monotonic revision, so this reflects true causal order across resources. Where it's absent (simulation) or equal, behavior is unchanged.
- Flag near-simultaneous entries (within 1s of a neighbor) with a dim `≈` marker, since their order is inferred rather than clearly separated in wall-clock time. Explained in the help overlay.

## Caveat
The Kubernetes API contract technically says resourceVersion is opaque and not comparable across resource types. In practice it holds on standard etcd clusters (including CRDs). The time fallback keeps things sane where it doesn't, and the `≈` marker tells the user when order was inferred.

Tests cover the comparator, the sort (including the inverted-observation case), and resourceVersion capture. `go test -race ./...` green.