### PR TITLE
docs: update README for v2 flags (--replay, --append, --no-compress, --simulate)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ loog -f 'Namespaces("prod","kube-system")' v1/pods
 ```
 
 **Resources** are specified as Group/Version/Resource (`GVR`) strings, e.g. `v1/pods`, `apps/v1/deployments`,
-`batch/v1/jobs`. You must provide **at least one resource** to watch or load an older recording using `--output [FILE]` file (or both).
+`batch/v1/jobs`. You must provide **at least one resource** to watch, an `--output [FILE]` to record into, or
+`--replay [FILE]` to browse an existing recording.
+
+> [!TIP]
+> Just want to try the UI without a cluster? `loog --simulate` runs the TUI on generated data.
+> Inside the TUI, press `?` for help and `ctrl+k` for the command palette.
 
 > [!NOTE]
 > _LOOG_ uses your kubeconfig and RBAC. You'll only see/list/watch what your credentials allow.
@@ -62,15 +67,31 @@ loog apps/v1/deployments v1/pods
 loog -H -o history.loog apps/v1/deployments v1/pods
 ```
 
-* Runs without UI and appends revisions to `history.loog` until interrupted.
+* Runs without UI and records revisions to `history.loog` until interrupted.
 * Safer for long-running collection jobs and CI.
 
 ```bash
-# Explore an existing file later (no new watches started)
-loog -o history.loog
+# Browse an existing recording read-only (no cluster connection)
+loog --replay history.loog
 ```
 
-* Opens the TUI over the saved revisions in `history.loog`.
+* Opens the TUI over the saved revisions in `history.loog` **without** connecting to Kubernetes or modifying the file.
+
+### Recording to a file
+
+Use `-o/--output FILE` to record revisions to a specific file.
+
+> [!IMPORTANT]
+> If `FILE` already exists, `loog` **refuses to start** so it never appends to a recording you meant to replay.
+> Pass `--append` to resume recording into it, or `--replay` to browse it read-only.
+
+```bash
+# Start a new recording (fails if the file already exists)
+loog -o history.loog v1/pods
+
+# Resume recording into an existing file
+loog --append -o history.loog v1/pods
+```
 
 ### Filtering
 
@@ -117,13 +138,15 @@ loog -f 'Object.GetLabels()["app"] == "web" && Object.GetNamespace() == "adm"' a
 > [!IMPORTANT]
 > Filters are evaluated **before writing** live events.
 > **Non-matching resources are *not added* to the database.**
-> When opening an existing `.loog` file, the filter acts as a **view** in the UI (it doesn't delete data).
+> When replaying an existing `.loog` file (`--replay`), the filter acts as a **view** and never modifies the file.
 
 ### Performance & Durability
 
 - `--snapshot-interval, -s <N>`: write a full snapshot every N patches (default `8`).
 - `--no-durable-sync`: skip fsync on each commit (higher throughput, **unsafe on crashes**).
 - `--disable-cache`: disable the in-memory cache layer.
+- `--no-compress`: store payloads uncompressed (larger file, slightly less CPU). Files are compressed by default;
+  `--replay` detects and reads either automatically.
 
 ### Kubeconfig & Debug
 


### PR DESCRIPTION
Checked the README against the current CLI and found several stale spots from the v2 work.

## Fixed
- **Browsing a recording**: the README told users to run `loog -o history.loog` to open an existing file. That now **errors** (since PR #40/#43, `-o` refuses an existing file). Replaced with `--replay history.loog`.
- **Line 44**: "load an older recording using `--output`" corrected to `--replay`.
- **Documented `--replay`** (read-only browse, no cluster) as a first-class mode, plus a new "Recording to a file" subsection explaining the existing-file guard.
- **Documented `--append`** (resume recording into an existing file).
- **Documented `--no-compress`** in Performance & Durability, noting `--replay` auto-detects compression.
- **Documented `--simulate`** as a no-cluster way to try the UI, with a TUI tip (`?` for help, `ctrl+k` for the command palette).
- Fixed the filter "view" note to reference `--replay`.

## Verified still accurate
- Shell completion commands (`loog completion ...`) still work.
- All Makefile targets referenced (`build`, `link-kubectl`, `link-k9s`, etc.) and the `compat/` files exist.
- Filtering helpers and examples match the current `util` env.