### PR TITLE
test(mux): fix flaky TestStop_ConcurrentDispatchNoPanic

### DIFF
--- a/pkg/mux/mux_test.go
+++ b/pkg/mux/mux_test.go
@@ -587,10 +587,13 @@ func TestStop_ConcurrentDispatchNoPanic(t *testing.T) {
 		t.Fatalf("Add: %v", err)
 	}
 
-	// Fire many events concurrently to maximize the chance of a
-	// dispatch in flight when Stop is called.
+	// Fire events concurrently to maximize the chance of a dispatch in flight
+	// when Stop is called. Keep the count below the fake watcher's fixed 100-slot
+	// channel: once Stop cancels the informer, the reflector stops draining that
+	// channel, and any further Creates would overflow it and panic ("channel
+	// full") inside the client-go fake watcher itself.
 	var wg sync.WaitGroup
-	for i := range 200 {
+	for i := range 50 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
`TestStop_ConcurrentDispatchNoPanic` panics sometimes in CI with `panic: channel full`, from `client-go`s fake watcher (`RaceFreeFakeWatcher.Add`, `watch.go:253`)

The test fires **200 concurrent `Create`s** into the fake dynamic client. Each event queues in the fake watcher, whose channel is hard-capped at **100**. Normally the informer's reflector drains it into the mux, but the test then calls `m.Stop()`, which cancels the informer context so the reflector **stops draining**. The remaining creates overflow the 100-slot buffer and the fake watcher panics. On slower/loaded CI runners the drain lags, so it overflows more often.