### PR TITLE
fix: prevent nil dereference in cleanup paths

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -321,7 +321,8 @@ func setupProduction(ctx context.Context, args []string) (
 	if outputFile == "" {
 		file, fileErr := os.CreateTemp("", "loog-output-*.loog")
 		if fileErr != nil {
-			return cleanup, nil, nil, nil, nil, fmt.Errorf("cannot create temp file: %w", fileErr)
+			err = fmt.Errorf("cannot create temp file: %w", fileErr)
+			return
 		}
 		outputFile = file.Name()
 		_ = file.Close() // bbolt reopens by path
@@ -345,7 +346,8 @@ func setupProduction(ctx context.Context, args []string) (
 		Msg("Compiling filter expression...")
 	prog, err = expr.Compile(filterExpr, expr.Env(util.EventEntryEnv{}), expr.AsBool())
 	if err != nil {
-		return cleanup, nil, nil, nil, nil, fmt.Errorf("error compiling filter expression: %w", err)
+		err = fmt.Errorf("error compiling filter expression: %w", err)
+		return
 	}
 
 	setupLog.Info().
@@ -357,7 +359,8 @@ func setupProduction(ctx context.Context, args []string) (
 		Compress:     !disableCompress,
 	})
 	if err != nil {
-		return cleanup, nil, nil, nil, nil, fmt.Errorf("error preparing store: %w", err)
+		err = fmt.Errorf("error preparing store: %w", err)
+		return
 	}
 	cleanups = append(cleanups, func() { _ = rps.Close() })
 	trackerService = service.NewTrackerService(rps, snapshotInterval, !disableCache)
@@ -366,26 +369,37 @@ func setupProduction(ctx context.Context, args []string) (
 	setupLog.Info().Msg("Preparing dynamic Kubernetes watch client...")
 	cfg, cfgErr := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
 	if cfgErr != nil {
-		return cleanup, nil, nil, nil, nil, fmt.Errorf("error loading kubeconfig: %w", cfgErr)
+		err = fmt.Errorf("error loading kubeconfig: %w", cfgErr)
+		return
 	}
 	dyn, dynErr := dynamic.NewForConfig(cfg)
 	if dynErr != nil {
-		return cleanup, nil, nil, nil, nil, fmt.Errorf("error creating dynamic watch client: %w", dynErr)
+		err = fmt.Errorf("error creating dynamic watch client: %w", dynErr)
+		return
 	}
 
 	m, err = mux.New(ctx, dyn)
 	if err != nil {
-		return cleanup, nil, nil, nil, nil, fmt.Errorf("error creating dynamic mux: %w", err)
+		err = fmt.Errorf("error creating dynamic mux: %w", err)
+		return
 	}
-	cleanups = append(cleanups, func() { m.Stop() })
+	cleanups = append(cleanups, func() {
+		// Defensive: the mux is only appended after a successful New above,
+		// but keep the guard so a future refactor can't reintroduce a nil deref.
+		if m != nil {
+			m.Stop()
+		}
+	})
 
 	for _, r := range args {
 		gvr, gvrParseErr := util.ParseGroupVersionResource(r)
 		if gvrParseErr != nil {
-			return cleanup, nil, nil, nil, nil, fmt.Errorf("cannot parse argument '%s' to GVR: %w", r, gvrParseErr)
+			err = fmt.Errorf("cannot parse argument '%s' to GVR: %w", r, gvrParseErr)
+			return
 		}
 		if muxAddErr := m.Add(gvr); muxAddErr != nil {
-			return cleanup, nil, nil, nil, nil, fmt.Errorf("cannot add GVR '%s' to dynamic mux: %w", gvr, muxAddErr)
+			err = fmt.Errorf("cannot add GVR '%s' to dynamic mux: %w", gvr, muxAddErr)
+			return
 		}
 	}
 

--- a/cmd/setup_test.go
+++ b/cmd/setup_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSetupProduction_ErrorPathDoesNotPanic guards against a regression where
+// setupProduction's error paths did:
+//
+//	return cleanup, nil, nil, nil, nil, err
+//
+// which zeroed the named-return variables (trackerService, rps, m). The
+// cleanup closures capture those variables, so a subsequent `defer cleanup()`
+// in the caller would deref nil and panic instead of releasing resources and
+// surfacing the real error.
+func TestSetupProduction_ErrorPathDoesNotPanic(t *testing.T) {
+	dir := t.TempDir()
+
+	// Save + restore every package flag setupProduction reads.
+	saved := struct {
+		filterExpr       string
+		kubeConfigPath   string
+		outputFile       string
+		snapshotInterval uint64
+		noDurableSync    bool
+		disableCache     bool
+		disableCompress  bool
+		headlessMode     bool
+	}{
+		filterExpr:       filterExpr,
+		kubeConfigPath:   kubeConfigPath,
+		outputFile:       outputFile,
+		snapshotInterval: snapshotInterval,
+		noDurableSync:    noDurableSync,
+		disableCache:     disableCache,
+		disableCompress:  disableCompress,
+		headlessMode:     headlessMode,
+	}
+	t.Cleanup(func() {
+		filterExpr = saved.filterExpr
+		kubeConfigPath = saved.kubeConfigPath
+		outputFile = saved.outputFile
+		snapshotInterval = saved.snapshotInterval
+		noDurableSync = saved.noDurableSync
+		disableCache = saved.disableCache
+		disableCompress = saved.disableCompress
+		headlessMode = saved.headlessMode
+	})
+
+	filterExpr = "All()"
+	kubeConfigPath = filepath.Join(dir, "definitely-not-a-kubeconfig")
+	outputFile = filepath.Join(dir, "capture.loog")
+	snapshotInterval = 8
+	noDurableSync = false
+	disableCache = false
+	disableCompress = false
+	headlessMode = false
+
+	cleanup, _, ts, rps, _, err := setupProduction(context.Background(), nil)
+	if err == nil {
+		t.Fatalf("expected setupProduction to fail with a bogus kubeconfig")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "kubeconfig") {
+		t.Fatalf("expected kubeconfig error, got: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatalf("cleanup must be non-nil so callers can safely `defer cleanup()`")
+	}
+
+	// The two named returns that MUST NOT be zeroed on error. Their cleanup
+	// closures capture them; nil'ing them is what caused the panic.
+	if ts == nil {
+		t.Errorf("trackerService returned nil after failure - cleanup closure would panic")
+	}
+	if rps == nil {
+		t.Errorf("rps returned nil after failure - cleanup closure would panic")
+	}
+
+	// The real regression assertion: cleanup must run to completion without
+	// panicking, no matter which step failed.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("cleanup panicked: %v", r)
+		}
+	}()
+	cleanup()
+
+	// Idempotent: a second cleanup call (e.g. via nested defer) must also
+	// be safe. Close methods on the store and tracker service are guarded by
+	// sync.Once and a nil-receiver check.
+	cleanup()
+}

--- a/internal/service/tracker_service.go
+++ b/internal/service/tracker_service.go
@@ -60,6 +60,9 @@ func NewTrackerService(rps store.ResourcePatchStore, snapshotEvery uint64, withC
 // Close closes the TrackerService and releases any resources it holds.
 // After you call Close, the TrackerService should not be used anymore.
 func (t *TrackerService) Close() error {
+	if t == nil {
+		return nil
+	}
 	t.closeOnce.Do(func() {
 		close(t.stopCommitLockJanitor)
 

--- a/internal/store/bbolt/store.go
+++ b/internal/store/bbolt/store.go
@@ -157,6 +157,9 @@ func (s *Store) syncLoop(interval time.Duration) {
 
 // Close flushes any pending writes and closes the database. It is idempotent.
 func (s *Store) Close() error {
+	if s == nil {
+		return nil
+	}
 	var err error
 	s.closeOnce.Do(func() {
 		if s.stopSync != nil {

--- a/pkg/mux/mux.go
+++ b/pkg/mux/mux.go
@@ -239,6 +239,9 @@ func (m *Mux) Events() <-chan watch.Event {
 // Stop terminates all watches and closes the event channel. It is safe
 // to call multiple times.
 func (m *Mux) Stop() {
+	if m == nil {
+		return
+	}
 	m.mu.Lock()
 	if m.stopped {
 		m.mu.Unlock()


### PR DESCRIPTION
## What & why

Fixes an issue where an invalid kubeconfig led to a nil pointer dereference because the cleanup paths were overridden in that case.
