### PR TITLE
feat(kubeconfig): enhance kubeconfig resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ loog -f 'Object.GetLabels()["app"] == "web" && Object.GetNamespace() == "adm"' a
 
 ### Kubeconfig & Debug
 
-- `--kubeconfig <path>` (default: `$HOME/.kube/config`)
+- `--kubeconfig <path>`: explicit kubeconfig. When unset, `loog` resolves the kubeconfig like `kubectl` does: it honors the `KUBECONFIG` environment variable (including a merged list of files) and otherwise falls back to `$HOME/.kube/config`.
 - `--debug`: write verbose logs to `debug.log` (`--truncate-debug` to start fresh)
   - this is useful for debugging the TUI
 

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/loog-project/loog/internal/resource"
 )
@@ -28,6 +27,13 @@ func loadClusterGVRs(kubeConfigPath string) ([]string, error) {
 	const cacheTTL = 60 * time.Second
 
 	cacheKey := strings.ReplaceAll(kubeConfigPath, string(os.PathSeparator), "_")
+	if cacheKey == "" {
+		if env := os.Getenv("KUBECONFIG"); env != "" {
+			cacheKey = strings.ReplaceAll(env, string(os.PathSeparator), "_")
+		} else {
+			cacheKey = "default"
+		}
+	}
 	cachePath := filepath.Join(os.TempDir(), "loog_complete_"+cacheKey+".json")
 	if info, err := os.Stat(cachePath); err == nil && time.Since(info.ModTime()) < cacheTTL {
 		if data, err := os.ReadFile(cachePath); err == nil {
@@ -38,7 +44,7 @@ func loadClusterGVRs(kubeConfigPath string) ([]string, error) {
 		}
 	}
 
-	cfg, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	cfg, err := restConfigForKubeconfig(kubeConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("building kube config: %w", err)
 	}
@@ -107,7 +113,7 @@ func gvrCompletion(_ *cobra.Command, _ []string, _ string) ([]string, cobra.Shel
 // and returns them as []resource.Kind for use by the WatchManager.
 // It reuses the same discovery API as loadClusterGVRs but extracts richer metadata.
 func loadClusterResourceKinds(kubeConfigPath string) ([]resource.Kind, error) {
-	cfg, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	cfg, err := restConfigForKubeconfig(kubeConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("building kube config: %w", err)
 	}

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func restConfigForKubeconfig(explicitPath string) (*rest.Config, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if explicitPath != "" {
+		rules.ExplicitPath = explicitPath
+	}
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		rules, &clientcmd.ConfigOverrides{},
+	).ClientConfig()
+}

--- a/cmd/kubeconfig_test.go
+++ b/cmd/kubeconfig_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeKubeconfig writes a minimal single-cluster kubeconfig pointing at server
+// and returns its path.
+func writeKubeconfig(t *testing.T, dir, name, ctx, server string) string {
+	t.Helper()
+	content := "" +
+		"apiVersion: v1\n" +
+		"kind: Config\n" +
+		"clusters:\n" +
+		"- name: " + ctx + "\n" +
+		"  cluster:\n" +
+		"    server: " + server + "\n" +
+		"contexts:\n" +
+		"- name: " + ctx + "\n" +
+		"  context:\n" +
+		"    cluster: " + ctx + "\n" +
+		"    user: " + ctx + "\n" +
+		"current-context: " + ctx + "\n" +
+		"users:\n" +
+		"- name: " + ctx + "\n" +
+		"  user: {}\n"
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	return p
+}
+
+func TestRestConfigForKubeconfig_RespectsKUBECONFIG(t *testing.T) {
+	dir := t.TempDir()
+	fileA := writeKubeconfig(t, dir, "a.yaml", "a", "https://a.example:6443")
+
+	t.Setenv("KUBECONFIG", fileA)
+
+	cfg, err := restConfigForKubeconfig("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Host != "https://a.example:6443" {
+		t.Errorf("expected KUBECONFIG cluster host, got %q", cfg.Host)
+	}
+}
+
+func TestRestConfigForKubeconfig_ExplicitOverridesKUBECONFIG(t *testing.T) {
+	dir := t.TempDir()
+	fileA := writeKubeconfig(t, dir, "a.yaml", "a", "https://a.example:6443")
+	fileB := writeKubeconfig(t, dir, "b.yaml", "b", "https://b.example:6443")
+
+	t.Setenv("KUBECONFIG", fileA)
+
+	// --kubeconfig must win over KUBECONFIG, like `kubectl --kubeconfig`.
+	cfg, err := restConfigForKubeconfig(fileB)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Host != "https://b.example:6443" {
+		t.Errorf("explicit --kubeconfig should win; got host %q", cfg.Host)
+	}
+}
+
+func TestRestConfigForKubeconfig_MergesKUBECONFIGList(t *testing.T) {
+	dir := t.TempDir()
+	fileA := writeKubeconfig(t, dir, "a.yaml", "a", "https://a.example:6443")
+	fileB := writeKubeconfig(t, dir, "b.yaml", "b", "https://b.example:6443")
+
+	// A colon/semicolon-separated list is merged; current-context comes from
+	// the first file that sets it (file A here), matching kubectl.
+	t.Setenv("KUBECONFIG", fileA+string(os.PathListSeparator)+fileB)
+
+	cfg, err := restConfigForKubeconfig("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Host != "https://a.example:6443" {
+		t.Errorf("merged list should use first file's current-context; got %q", cfg.Host)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -23,8 +22,6 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
 	"k8s.io/klog/v2"
 
 	"github.com/loog-project/loog/internal/adapter"
@@ -85,12 +82,8 @@ func init() {
 	// global flags
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "",
 		"config file (default is $HOME/.loog.yaml)")
-	defaultKube := ""
-	if home := homedir.HomeDir(); home != "" {
-		defaultKube = filepath.Join(home, ".kube", "config")
-	}
-	rootCmd.PersistentFlags().StringVar(&kubeConfigPath, "kubeconfig", defaultKube,
-		"Path to the kubeconfig file (defaults to $HOME/.kube/config)")
+	rootCmd.PersistentFlags().StringVar(&kubeConfigPath, "kubeconfig", "",
+		"Path to the kubeconfig file (overrides $KUBECONFIG; defaults to $KUBECONFIG or $HOME/.kube/config)")
 	rootCmd.PersistentFlags().BoolVar(&enableDebugMode, "debug", false,
 		"Enable debug mode, which will print additional information to the debug.log file")
 	rootCmd.PersistentFlags().BoolVar(&truncateDebugLog, "truncate-debug", false,
@@ -364,9 +357,10 @@ func setupProduction(ctx context.Context, args []string) (
 	cleanups = append(cleanups, func() { _ = trackerService.Close() })
 
 	setupLog.Info().Msg("Preparing dynamic Kubernetes watch client...")
-	cfg, cfgErr := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	cfg, cfgErr := restConfigForKubeconfig(kubeConfigPath)
 	if cfgErr != nil {
-		return cleanup, nil, nil, nil, nil, fmt.Errorf("error loading kubeconfig: %w", cfgErr)
+		err = fmt.Errorf("error loading kubeconfig: %w", cfgErr)
+		return
 	}
 	dyn, dynErr := dynamic.NewForConfig(cfg)
 	if dynErr != nil {


### PR DESCRIPTION
## What & why

Currently, loog reads the kubeconfig from `$HOME/.kube/config` OR explicit `--kubeconfig`.
This pull request changes this behavior to read from `$KUBECONFIG` with an optional override from `--kubeconfig`.

Closes #59 

## How it was tested

Added tests for restConfigForKubeconfig

## Checklist

- [x] `go build ./...` and `go test ./...` pass
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, `docs:`, ...)
- [x] Docs/README updated if behaviour or flags changed
