### PR TITLE
feat: `--context` flag to specify kube context

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ loog -f 'Object.GetLabels()["app"] == "web" && Object.GetNamespace() == "adm"' a
 ### Kubeconfig & Debug
 
 - `--kubeconfig <path>`: explicit kubeconfig. When unset, `loog` resolves the kubeconfig like `kubectl` does: it honors the `KUBECONFIG` environment variable (including a merged list of files) and otherwise falls back to `$HOME/.kube/config`.
+- `--context <name>`: kubeconfig context to use for the session (defaults to the current context), like `kubectl --context`.
 - `--debug`: write verbose logs to `debug.log` (`--truncate-debug` to start fresh)
   - this is useful for debugging the TUI
 

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -23,7 +23,7 @@ var (
 )
 
 // loadClusterGVRs loads the GroupVersionResources (GVRs) from the Kubernetes cluster
-func loadClusterGVRs(kubeConfigPath string) ([]string, error) {
+func loadClusterGVRs(kubeConfigPath, kubeContext string) ([]string, error) {
 	const cacheTTL = 60 * time.Second
 
 	cacheKey := strings.ReplaceAll(kubeConfigPath, string(os.PathSeparator), "_")
@@ -33,6 +33,10 @@ func loadClusterGVRs(kubeConfigPath string) ([]string, error) {
 		} else {
 			cacheKey = "default"
 		}
+	}
+	if kubeContext != "" {
+		// Different contexts point at different clusters; scope the cache.
+		cacheKey += "@" + kubeContext
 	}
 	cachePath := filepath.Join(os.TempDir(), "loog_complete_"+cacheKey+".json")
 	if info, err := os.Stat(cachePath); err == nil && time.Since(info.ModTime()) < cacheTTL {
@@ -44,7 +48,7 @@ func loadClusterGVRs(kubeConfigPath string) ([]string, error) {
 		}
 	}
 
-	cfg, err := restConfigForKubeconfig(kubeConfigPath)
+	cfg, err := restConfigForKubeconfig(kubeConfigPath, kubeContext)
 	if err != nil {
 		return nil, fmt.Errorf("building kube config: %w", err)
 	}
@@ -102,7 +106,7 @@ func loadClusterGVRs(kubeConfigPath string) ([]string, error) {
 
 func gvrCompletion(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 	gvrsOnce.Do(func() {
-		if s, err := loadClusterGVRs(kubeConfigPath); err == nil {
+		if s, err := loadClusterGVRs(kubeConfigPath, kubeContext); err == nil {
 			cachedGVRs = s
 		}
 	})
@@ -112,8 +116,8 @@ func gvrCompletion(_ *cobra.Command, _ []string, _ string) ([]string, cobra.Shel
 // loadClusterResourceKinds discovers all watchable resource types from the cluster
 // and returns them as []resource.Kind for use by the WatchManager.
 // It reuses the same discovery API as loadClusterGVRs but extracts richer metadata.
-func loadClusterResourceKinds(kubeConfigPath string) ([]resource.Kind, error) {
-	cfg, err := restConfigForKubeconfig(kubeConfigPath)
+func loadClusterResourceKinds(kubeConfigPath, kubeContext string) ([]resource.Kind, error) {
+	cfg, err := restConfigForKubeconfig(kubeConfigPath, kubeContext)
 	if err != nil {
 		return nil, fmt.Errorf("building kube config: %w", err)
 	}

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -5,12 +5,31 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func restConfigForKubeconfig(explicitPath string) (*rest.Config, error) {
+// restConfigForKubeconfig builds a *rest.Config the same way kubectl resolves
+// its kubeconfig, in this order of precedence:
+//
+//  1. an explicit path (the --kubeconfig flag), when non-empty;
+//  2. the KUBECONFIG environment variable, which may list several files to
+//     merge (os.PathListSeparator-separated), like kubectl;
+//  3. the default ~/.kube/config.
+//
+// contextName, when non-empty, overrides the current-context (the --context
+// flag), matching `kubectl --context`. Passing empty strings yields the
+// KUBECONFIG / ~/.kube/config file and its current-context.
+func restConfigForKubeconfig(explicitPath, contextName string) (*rest.Config, error) {
+	// NewDefaultClientConfigLoadingRules reads KUBECONFIG (a precedence list of
+	// files to merge) and falls back to RecommendedHomeFile (~/.kube/config).
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	if explicitPath != "" {
+		// An explicit --kubeconfig takes priority over KUBECONFIG and the
+		// default file, matching `kubectl --kubeconfig`.
 		rules.ExplicitPath = explicitPath
 	}
+	overrides := &clientcmd.ConfigOverrides{}
+	if contextName != "" {
+		overrides.CurrentContext = contextName
+	}
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		rules, &clientcmd.ConfigOverrides{},
+		rules, overrides,
 	).ClientConfig()
 }

--- a/cmd/kubeconfig_test.go
+++ b/cmd/kubeconfig_test.go
@@ -39,7 +39,7 @@ func TestRestConfigForKubeconfig_RespectsKUBECONFIG(t *testing.T) {
 
 	t.Setenv("KUBECONFIG", fileA)
 
-	cfg, err := restConfigForKubeconfig("")
+	cfg, err := restConfigForKubeconfig("", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestRestConfigForKubeconfig_ExplicitOverridesKUBECONFIG(t *testing.T) {
 	t.Setenv("KUBECONFIG", fileA)
 
 	// --kubeconfig must win over KUBECONFIG, like `kubectl --kubeconfig`.
-	cfg, err := restConfigForKubeconfig(fileB)
+	cfg, err := restConfigForKubeconfig(fileB, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -74,11 +74,64 @@ func TestRestConfigForKubeconfig_MergesKUBECONFIGList(t *testing.T) {
 	// the first file that sets it (file A here), matching kubectl.
 	t.Setenv("KUBECONFIG", fileA+string(os.PathListSeparator)+fileB)
 
-	cfg, err := restConfigForKubeconfig("")
+	cfg, err := restConfigForKubeconfig("", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if cfg.Host != "https://a.example:6443" {
 		t.Errorf("merged list should use first file's current-context; got %q", cfg.Host)
+	}
+}
+
+// writeTwoContextKubeconfig writes a kubeconfig with two contexts (a -> serverA,
+// b -> serverB) whose current-context is "a", and returns its path.
+func writeTwoContextKubeconfig(t *testing.T, dir, name, serverA, serverB string) string {
+	t.Helper()
+	content := "" +
+		"apiVersion: v1\n" +
+		"kind: Config\n" +
+		"clusters:\n" +
+		"- name: a\n  cluster:\n    server: " + serverA + "\n" +
+		"- name: b\n  cluster:\n    server: " + serverB + "\n" +
+		"contexts:\n" +
+		"- name: a\n  context:\n    cluster: a\n    user: a\n" +
+		"- name: b\n  context:\n    cluster: b\n    user: b\n" +
+		"current-context: a\n" +
+		"users:\n" +
+		"- name: a\n  user: {}\n" +
+		"- name: b\n  user: {}\n"
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatalf("write kubeconfig: %v", err)
+	}
+	return p
+}
+
+func TestRestConfigForKubeconfig_ContextOverride(t *testing.T) {
+	dir := t.TempDir()
+	file := writeTwoContextKubeconfig(t, dir, "kc.yaml", "https://a.example:6443", "https://b.example:6443")
+	t.Setenv("KUBECONFIG", file)
+
+	// No override -> current-context "a".
+	cfg, err := restConfigForKubeconfig("", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Host != "https://a.example:6443" {
+		t.Errorf("without --context expected current-context 'a'; got %q", cfg.Host)
+	}
+
+	// --context b selects the other cluster, like `kubectl --context b`.
+	cfg, err = restConfigForKubeconfig("", "b")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Host != "https://b.example:6443" {
+		t.Errorf("--context b should select cluster b; got %q", cfg.Host)
+	}
+
+	// A non-existent context is an error, not a silent fallback.
+	if _, err := restConfigForKubeconfig("", "does-not-exist"); err == nil {
+		t.Errorf("expected error for unknown context")
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,7 @@ var (
 	// persistent flags
 	cfgFile          string
 	kubeConfigPath   string
+	kubeContext      string
 	enableDebugMode  bool
 	truncateDebugLog bool
 
@@ -84,6 +85,8 @@ func init() {
 		"config file (default is $HOME/.loog.yaml)")
 	rootCmd.PersistentFlags().StringVar(&kubeConfigPath, "kubeconfig", "",
 		"Path to the kubeconfig file (overrides $KUBECONFIG; defaults to $KUBECONFIG or $HOME/.kube/config)")
+	rootCmd.PersistentFlags().StringVar(&kubeContext, "context", "",
+		"Name of the kubeconfig context to use (defaults to the current context)")
 	rootCmd.PersistentFlags().BoolVar(&enableDebugMode, "debug", false,
 		"Enable debug mode, which will print additional information to the debug.log file")
 	rootCmd.PersistentFlags().BoolVar(&truncateDebugLog, "truncate-debug", false,
@@ -360,7 +363,7 @@ func setupProduction(ctx context.Context, args []string) (
 	cleanups = append(cleanups, func() { _ = trackerService.Close() })
 
 	setupLog.Info().Msg("Preparing dynamic Kubernetes watch client...")
-	cfg, cfgErr := restConfigForKubeconfig(kubeConfigPath)
+	cfg, cfgErr := restConfigForKubeconfig(kubeConfigPath, kubeContext)
 	if cfgErr != nil {
 		err = fmt.Errorf("error loading kubeconfig: %w", cfgErr)
 		return
@@ -483,7 +486,7 @@ func runInteractive(
 
 	// Discover cluster resource kinds in the background for WatchManager
 	go func() {
-		kinds, err := loadClusterResourceKinds(kubeConfigPath)
+		kinds, err := loadClusterResourceKinds(kubeConfigPath, kubeContext)
 		if err != nil {
 			log.Warn().Err(err).Msg("Failed to discover cluster resource kinds for WatchManager")
 			return


### PR DESCRIPTION
<!-- Thanks for contributing to loog! Keep PRs focused; open an issue first for
larger changes so the direction can be agreed before you invest time. -->

## What & why

Allows the user to specify the kube context by passing the `--context` flag :)

Closes n/a

## How it was tested

- [x] Added tests

## Checklist

- [x] `go build ./...` and `go test ./...` pass
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, `docs:`, ...)
- [x] Docs/README updated if behaviour or flags changed
