### PR TITLE
feat: implement resource deletion tracking and visual indicators

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
 
@@ -655,7 +656,13 @@ func runCollector(
 
 			// empty managed fields before committing as they only clutter and we in 99/100 cases don't need them
 			obj.SetManagedFields(nil)
-			revisionID, err := trackerService.Commit(ctx, string(obj.GetUID()), obj)
+
+			var revisionID store.RevisionID
+			if ev.Type == watch.Deleted {
+				revisionID, err = trackerService.CommitDelete(ctx, string(obj.GetUID()), obj)
+			} else {
+				revisionID, err = trackerService.Commit(ctx, string(obj.GetUID()), obj)
+			}
 			if err != nil {
 				var dupErr service.DuplicateResourceVersionError
 				if errors.As(err, &dupErr) {

--- a/internal/adapter/handler.go
+++ b/internal/adapter/handler.go
@@ -85,17 +85,23 @@ func buildRevision(
 		rev.PreviousID = snapshot.PreviousID
 		rev.Time = snapshot.Time
 
-		// First revision (no previous) -> ADDED, otherwise MODIFIED
-		if snapshot.PreviousID == 0 {
+		switch {
+		case snapshot.Deleted:
+			rev.EventType = resource.EventDeleted
+		case snapshot.PreviousID == 0:
 			rev.EventType = resource.EventAdded
-		} else {
+		default:
 			rev.EventType = resource.EventModified
 		}
 	} else if patch != nil {
 		rev.PreviousID = patch.PreviousID
 		rev.Time = patch.Time
 		rev.Patch = resource.CloneMap(patch.Patch)
-		rev.EventType = resource.EventModified
+		if patch.Deleted {
+			rev.EventType = resource.EventDeleted
+		} else {
+			rev.EventType = resource.EventModified
+		}
 	}
 
 	return rev

--- a/internal/adapter/history_test.go
+++ b/internal/adapter/history_test.go
@@ -80,3 +80,29 @@ func TestBuildRevision_FirstSnapshotIsAdded(t *testing.T) {
 		t.Errorf("first snapshot event = %v, want ADDED", rev.EventType)
 	}
 }
+
+// A snapshot flagged Deleted maps to DELETED regardless of PreviousID.
+func TestBuildRevision_DeletedSnapshotIsDeleted(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{"kind": "Pod"}}
+
+	// Deleted first-and-only snapshot (PreviousID 0) is still DELETED, not ADDED.
+	snap := &store.Snapshot{PreviousID: 0, Time: time.Now(), Deleted: true}
+	if rev := buildRevision(obj, 1, snap, nil); rev.EventType != resource.EventDeleted {
+		t.Errorf("deleted snapshot event = %v, want DELETED", rev.EventType)
+	}
+
+	// Deleted snapshot with prior history is DELETED, not MODIFIED.
+	snap2 := &store.Snapshot{PreviousID: 8, Time: time.Now(), Deleted: true}
+	if rev := buildRevision(obj, 9, snap2, nil); rev.EventType != resource.EventDeleted {
+		t.Errorf("deleted later snapshot event = %v, want DELETED", rev.EventType)
+	}
+}
+
+// A patch flagged Deleted maps to DELETED instead of MODIFIED.
+func TestBuildRevision_DeletedPatchIsDeleted(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{"kind": "Pod"}}
+	patch := &store.Patch{PreviousID: 5, Time: time.Now(), Deleted: true}
+	if rev := buildRevision(obj, 6, nil, patch); rev.EventType != resource.EventDeleted {
+		t.Errorf("deleted patch event = %v, want DELETED", rev.EventType)
+	}
+}

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -112,6 +112,13 @@ func (rd *Data) LatestRevision() *Revision {
 	return &rd.Revisions[len(rd.Revisions)-1]
 }
 
+// IsDeleted reports whether the resource's most recent revision is a deletion,
+// i.e. the resource no longer exists on the cluster.
+func (rd *Data) IsDeleted() bool {
+	latest := rd.LatestRevision()
+	return latest != nil && latest.EventType == EventDeleted
+}
+
 // CreationTime returns the Kubernetes creationTimestamp from the first
 // revision's object metadata. Returns zero time if unavailable.
 func (rd *Data) CreationTime() time.Time {

--- a/internal/service/tracker_service.go
+++ b/internal/service/tracker_service.go
@@ -172,6 +172,43 @@ func (t *TrackerService) Commit(
 	return p.ID, nil
 }
 
+// CommitDelete records that *lastObject* was deleted from the cluster and
+// returns the new revision ID. Unlike Commit, it always produces a new revision.
+func (t *TrackerService) CommitDelete(
+	ctx context.Context,
+	objID string,
+	lastObject *unstructured.Unstructured,
+) (store.RevisionID, error) {
+	lw := t.lockObject(objID)
+	defer lw.mu.Unlock()
+
+	var previousID store.RevisionID
+	var ts *trackerState
+	if t.cache != nil {
+		ts = t.cache.get(objID)
+	}
+	if ts != nil {
+		previousID = ts.rev
+	} else if latest, err := t.rps.GetLatestRevision(ctx, objID); err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			return 0, err
+		}
+	} else {
+		previousID = latest
+	}
+
+	snapshot := newSnapshot(lastObject, previousID)
+	snapshot.Deleted = true
+	if err := t.rps.SetSnapshot(ctx, objID, &snapshot); err != nil {
+		return 0, err
+	}
+
+	if t.cache != nil {
+		t.cache.set(objID, &trackerState{obj: snapshot.Object, rev: snapshot.ID})
+	}
+	return snapshot.ID, nil
+}
+
 func newPatch(previousID store.RevisionID, diff diffmap.DiffMap) store.Patch {
 	return store.Patch{
 		PreviousID: previousID,

--- a/internal/service/tracker_service_test.go
+++ b/internal/service/tracker_service_test.go
@@ -100,6 +100,71 @@ func TestCommitRestore_RotationAndDiff(t *testing.T) {
 	}
 }
 
+func TestCommitDelete_RecordsDeletedRevision(t *testing.T) {
+	ctx := context.Background()
+	svc, raw := mustNewSvc(t, 8, true, true)
+
+	uid := "uid-del"
+	obj := newCM(uid)
+
+	// initial add + one update
+	rev0, _ := svc.Commit(ctx, uid, obj.DeepCopy())
+	obj.Object["data"].(diffmap.DiffMap)["val"] = "y"
+	obj.Object["metadata"].(diffmap.DiffMap)["resourceVersion"] = "2"
+	rev1, _ := svc.Commit(ctx, uid, obj.DeepCopy())
+
+	// delete
+	delRev, err := svc.CommitDelete(ctx, uid, obj.DeepCopy())
+	if err != nil {
+		t.Fatalf("CommitDelete: %v", err)
+	}
+	if delRev <= rev1 {
+		t.Fatalf("delete revision %d should be newer than %d", delRev, rev1)
+	}
+
+	snap, patch, err := raw.Get(ctx, uid, delRev)
+	if err != nil {
+		t.Fatalf("Get delete revision: %v", err)
+	}
+	if snap == nil {
+		t.Fatalf("delete revision should be stored as a snapshot, got patch=%v", patch)
+	}
+	if !snap.Deleted {
+		t.Errorf("delete snapshot Deleted = false, want true")
+	}
+	if snap.PreviousID != rev1 {
+		t.Errorf("delete snapshot PreviousID = %d, want %d", snap.PreviousID, rev1)
+	}
+	// The last observed state must be preserved.
+	if got := snap.Object["data"].(diffmap.DiffMap)["val"]; got != "y" {
+		t.Errorf("delete snapshot object val = %v, want y", got)
+	}
+	_ = rev0
+}
+
+// CommitDelete for a never-before-seen object still records a deleted revision
+// (PreviousID 0) rather than erroring.
+func TestCommitDelete_ColdStart(t *testing.T) {
+	ctx := context.Background()
+	svc, raw := mustNewSvc(t, 8, true, false)
+
+	uid := "uid-del-cold"
+	delRev, err := svc.CommitDelete(ctx, uid, newCM(uid))
+	if err != nil {
+		t.Fatalf("CommitDelete cold: %v", err)
+	}
+	snap, _, err := raw.Get(ctx, uid, delRev)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if snap == nil || !snap.Deleted {
+		t.Fatalf("expected deleted snapshot, got %#v", snap)
+	}
+	if snap.PreviousID != 0 {
+		t.Errorf("cold delete PreviousID = %d, want 0", snap.PreviousID)
+	}
+}
+
 func TestHotCache_FastPath(t *testing.T) {
 	ctx := context.Background()
 	svc, _ := mustNewSvc(t, 8, true, true)
@@ -107,8 +172,7 @@ func TestHotCache_FastPath(t *testing.T) {
 	uid := "uid-cache"
 	obj := newCM(uid)
 
-	// first commit fills cache
-	_, _ = svc.Commit(ctx, uid, obj.DeepCopy())
+	// first commit fills cache	_, _ = svc.Commit(ctx, uid, obj.DeepCopy())
 
 	// mutate & commit again
 	obj.Object["data"].(diffmap.DiffMap)["val"] = "cached"

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -24,6 +24,9 @@ type Patch struct {
 	// See [diffmap.Diff] for more details.
 	Patch diffmap.DiffMap `msgpack:"s" json:"patch,omitempty"`
 	Time  time.Time       `msgpack:"t" json:"time"`
+
+	// Deleted marks this revision as the point at which the resource was removed from the cluster.
+	Deleted bool `msgpack:"d,omitempty" json:"deleted,omitempty"`
 }
 
 type Snapshot struct {
@@ -35,4 +38,8 @@ type Snapshot struct {
 	// Object is the full resource state stored in this revision.
 	Object diffmap.DiffMap `msgpack:"o" json:"object,omitempty"`
 	Time   time.Time       `msgpack:"t" json:"time"`
+
+	// Deleted marks this revision as the point at which the resource was removed from the cluster.
+	// Object holds the last observed state before deletion.
+	Deleted bool `msgpack:"d,omitempty" json:"deleted,omitempty"`
 }

--- a/internal/tui/components.go
+++ b/internal/tui/components.go
@@ -656,6 +656,11 @@ func (rt *ResourceTree) View() string {
 					}
 				}
 
+				deleted := rd.IsDeleted()
+				if deleted {
+					indicator = lipgloss.NewStyle().Foreground(rt.theme.Red).Render("✗")
+				}
+
 				loopBadge := ""
 				if rd.DetectLoop(6) {
 					loopBadge = " " + lipgloss.NewStyle().
@@ -681,6 +686,9 @@ func (rt *ResourceTree) View() string {
 
 				name := r.ShortName(maxNameLen)
 				nameStyle := lipgloss.NewStyle().Foreground(rt.theme.Text)
+				if deleted {
+					nameStyle = nameStyle.Foreground(rt.theme.Overlay1).Strikethrough(true)
+				}
 
 				if isDimmed {
 					dimColor := rt.theme.Surface2
@@ -1098,7 +1106,11 @@ func (rl *RevisionList) View() string {
 			dot = lipgloss.NewStyle().Foreground(rl.theme.Blue).Render("●")
 		}
 
-		idStr := lipgloss.NewStyle().Foreground(rl.theme.Mauve).Render(rev.ID.String())
+		idStyle := lipgloss.NewStyle().Foreground(rl.theme.Mauve)
+		if rev.EventType == resource.EventDeleted {
+			idStyle = idStyle.Strikethrough(true)
+		}
+		idStr := idStyle.Render(rev.ID.String())
 
 		etStyle := rl.theme.EventTypeStyle(rev.EventType)
 		etStr := etStyle.Render(rev.EventType.Symbol())
@@ -1276,6 +1288,14 @@ func (dv *DetailView) renderContent() {
 		body = RenderJSONObject(rev.Object, dv.theme)
 	case RawMode:
 		body = dv.renderRaw(rev)
+	}
+
+	// Call out deletions with a prominent banner so it's obvious the object no
+	// longer exists on the cluster; the body still shows its last known state.
+	if rev.EventType == resource.EventDeleted {
+		banner := dv.theme.ErrorStyle().Bold(true).
+			Render("  ✗ Resource deleted (showing last observed state)")
+		body = banner + "\n\n" + body
 	}
 
 	dv.content = titleLine + "\n" + separator + "\n" + body
@@ -2011,9 +2031,14 @@ func (tl *TimelineList) View() string {
 			kindName = lipgloss.NewStyle().Foreground(dimColor).Render(kindPrefix + nameStr)
 		} else {
 			kc := tl.theme.KindColor(e.Resource.Kind)
-			kindPart := lipgloss.NewStyle().Foreground(kc).Render(kindPrefix)
-			namePart := lipgloss.NewStyle().Foreground(tl.theme.Text).Render(nameStr)
-			kindName = kindPart + namePart
+			kindStyle := lipgloss.NewStyle().Foreground(kc)
+			nameStyle := lipgloss.NewStyle().Foreground(tl.theme.Text)
+			if e.Revision.EventType == resource.EventDeleted {
+				// Strike through deleted entries so they stand out beyond the (-) glyph.
+				kindStyle = kindStyle.Strikethrough(true)
+				nameStyle = nameStyle.Strikethrough(true)
+			}
+			kindName = kindStyle.Render(kindPrefix) + nameStyle.Render(nameStr)
 		}
 
 		etStr := ""


### PR DESCRIPTION
## What & why

Now tracks the deletion of resources to make it clear when and why a resource was deleted.

## How it was tested

- [x] added tests

## Checklist

- [x] `go build ./...` and `go test ./...` pass
- [x] Commits follow Conventional Commits (`feat:`, `fix:`, `docs:`, ...)
- [x] Docs/README updated if behaviour or flags changed
